### PR TITLE
Overwrite all lines in file when serializing

### DIFF
--- a/OpenTabletDriverGUI/Models/Settings.cs
+++ b/OpenTabletDriverGUI/Models/Settings.cs
@@ -202,6 +202,8 @@ namespace OpenTabletDriverGUI.Models
 
         public void Serialize(FileInfo file)
         {
+            if (file.Exists)
+                file.Delete();
             using (var stream = file.OpenWrite())
                 XmlSerializer.Serialize(stream, this);
         }


### PR DESCRIPTION
# Changes
- [x] Overwrites the entire XML file when serializing to avoid deserialization `System.InvalidOperationException` (resolves #37)