### PR TITLE
Expose raw reports as a debugging option

### DIFF
--- a/OpenTabletDriver/ViewModels/MainWindowViewModel.cs
+++ b/OpenTabletDriver/ViewModels/MainWindowViewModel.cs
@@ -168,6 +168,17 @@ namespace OpenTabletDriver.ViewModels
         }
         private bool _debugging;
 
+        public bool RawReports
+        {
+            set
+            {
+                this.RaiseAndSetIfChanged(ref _rawReports, value);
+                Driver.RawReports = value;
+            }
+            get => _rawReports;
+        }
+        private bool _rawReports;
+
         #endregion
 
         #region Buttons

--- a/OpenTabletDriver/Views/MainWindow.xaml
+++ b/OpenTabletDriver/Views/MainWindow.xaml
@@ -197,6 +197,7 @@
                             </Style>
                         </StackPanel.Styles>
                         <CheckBox Content="Debugging" IsChecked="{Binding Debugging}"/>
+                        <CheckBox Content="Raw Reports" IsChecked="{Binding RawReports}" IsVisible="{Binding Debugging}"/>
                     </StackPanel>
                 </Grid>
             </TabItem>

--- a/TabletDriverLib/Driver.cs
+++ b/TabletDriverLib/Driver.cs
@@ -11,6 +11,7 @@ namespace TabletDriverLib
     public class Driver : IDisposable
     {
         public static bool Debugging { set; get; }
+        public static bool RawReports { set; get; }
         public bool BindingEnabled { set; get; }
         
         public HidDevice Tablet { private set; get; }

--- a/TabletDriverLib/Tablet/AuxReport.cs
+++ b/TabletDriverLib/Tablet/AuxReport.cs
@@ -19,7 +19,7 @@ namespace TabletDriverLib.Tablet
         public byte[] Raw { private set; get; }
         public bool[] AuxButtons { private set; get; }
 
-        public override string ToString() => ToString(false);
+        public override string ToString() => ToString(Driver.RawReports);
 
         public string ToString(bool isRaw)
         {

--- a/TabletDriverLib/Tablet/TabletReport.cs
+++ b/TabletDriverLib/Tablet/TabletReport.cs
@@ -30,7 +30,7 @@ namespace TabletDriverLib.Tablet
         public uint Pressure { private set; get; }
         public bool[] PenButtons { private set; get; }
 
-        public override string ToString() => ToString(false);
+        public override string ToString() => ToString(Driver.RawReports);
 
         public string ToString(bool raw)
         {


### PR DESCRIPTION
This could help ease the development of custom tablet report parsers by allowing users to send more useful data.