### PR TITLE
Use full class path for plugin settings

### DIFF
--- a/OpenTabletDriver/Controls/PluginSettingsEditorViewModel.cs
+++ b/OpenTabletDriver/Controls/PluginSettingsEditorViewModel.cs
@@ -78,6 +78,10 @@ namespace OpenTabletDriver.Controls
             {
                 SelectedPluginTemplate = value?.Construct<T>();
                 PluginTools.SetPluginSettings(SelectedPluginTemplate, Settings.PluginSettings);
+                
+                if (SelectedPluginTemplate is INotifyPropertyChanged inotify)
+                    inotify.PropertyChanged += (s, e) => UpdateSettings(SelectedPluginTemplate);
+                
                 this.RaiseAndSetIfChanged(ref _selectedPlugin, value);
             }
             get => _selectedPlugin;
@@ -88,12 +92,8 @@ namespace OpenTabletDriver.Controls
         {
             set
             {
-                if (value is INotifyPropertyChanged inotify)
-                    inotify.PropertyChanged += (s, e) => UpdateSettings(value);
-
                 var pluginSettings = PropertyTools.GetPropertyControls(value, nameof(SelectedPluginTemplate), Settings.PluginSettings);
                 SelectedPluginSettings = new ObservableCollection<IControl>(pluginSettings);
-
                 this.RaiseAndSetIfChanged(ref _template, value);
             }
             get => _template;

--- a/OpenTabletDriver/Tools/PluginTools.cs
+++ b/OpenTabletDriver/Tools/PluginTools.cs
@@ -19,7 +19,7 @@ namespace OpenTabletDriver.Tools
                         select attr as PropertyAttribute;
 
                     if (attributes.Count() > 0)
-                        yield return (property.Name, property.GetValue(obj).ToString());
+                        yield return (obj.GetType().FullName + "." + property.Name, property.GetValue(obj).ToString());
                 }
             }
         }
@@ -34,7 +34,7 @@ namespace OpenTabletDriver.Tools
                         where attr is PropertyAttribute
                         select attr as PropertyAttribute;
 
-                    if (pluginSettings.TryGetValue(property.Name, out var stringValue))
+                    if (pluginSettings.TryGetValue(obj.GetType().FullName + "." + property.Name, out var stringValue))
                     {
                         var value = Convert.ChangeType(stringValue, property.PropertyType);
                         property.SetValue(obj, value);


### PR DESCRIPTION
# Changes
- [x] Use full class path for plugin settings
  - Example:
    ```
    "OpenTabletDriverPlugins.AntiSmoothingFilter.Compensation": "10"
    ```

## Bugfixes
- [x] Fix settings updating before loading finished