### PR TITLE
Remove Name property from IResident

### DIFF
--- a/TabletDriverPlugin/Resident/IResident.cs
+++ b/TabletDriverPlugin/Resident/IResident.cs
@@ -7,7 +7,6 @@ namespace TabletDriverPlugin.Resident
     /// </summary>
     public interface IResident : IDisposable
     {
-        string Name { get; }
         bool Initialize();
     }
 }


### PR DESCRIPTION
# Changes
- Removes `Name` property from `IResident`
  > Completely unnecessary property because `NamePropertyAttribute` exists. 