### PR TITLE
Update nuget package license

### DIFF
--- a/TabletDriverPlugin/TabletDriverPlugin.csproj
+++ b/TabletDriverPlugin/TabletDriverPlugin.csproj
@@ -10,6 +10,7 @@
     <Authors>InfinityGhost</Authors>
     <Description>Library used to create OpenTabletDriver plugins.</Description>
     <PackageOutputPath>./nupkg</PackageOutputPath>
+    <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Changes
- Added GPL 3.0 license to [NuGet Package](https://www.nuget.org/packages/TabletDriverPlugin/0.2.0)