### PR TITLE
Fix XP-Pen G640 configuration

### DIFF
--- a/TabletDriverLib/Configurations/XP-Pen/G640.json
+++ b/TabletDriverLib/Configurations/XP-Pen/G640.json
@@ -11,7 +11,7 @@
   "MaxX": 32000.0,
   "MaxY": 20000.0,
   "MaxPressure": 8191,
-  "ActiveReportID": 128,
+  "ActiveReportID": 64,
   "AuxReportLength": 0,
   "AuxReportParser": null,
   "FeatureInitReport": null


### PR DESCRIPTION
Fixes XP-Pen G640 configuration's minimum range.
Cursor was not moving without this fix.