### PR TITLE
Show display and tablet ratios

### DIFF
--- a/OpenTabletDriver/Settings.cs
+++ b/OpenTabletDriver/Settings.cs
@@ -81,7 +81,7 @@ namespace OpenTabletDriver
 
         public float DisplayRatio
         {
-            set => this.RaiseAndSetIfChanged(ref _dRatio, value);
+            private set => this.RaiseAndSetIfChanged(ref _dRatio, value);
             get => (float)Math.Round(_dRatio * 1000f) / 1000f;
         }
 
@@ -142,7 +142,7 @@ namespace OpenTabletDriver
 
         public float TabletRatio
         {
-            set => this.RaiseAndSetIfChanged(ref _tRatio, value);
+            private set => this.RaiseAndSetIfChanged(ref _tRatio, value);
             get => (float)Math.Round(_tRatio * 1000f) / 1000f;
         }
 

--- a/OpenTabletDriver/Settings.cs
+++ b/OpenTabletDriver/Settings.cs
@@ -75,7 +75,6 @@ namespace OpenTabletDriver
                 if (LockAspectRatio)
                     TabletWidth = DisplayWidth / DisplayHeight * TabletHeight;
                 DisplayRatio = DisplayWidth / DisplayHeight;
-                
             }
             get => _dH;
         }

--- a/OpenTabletDriver/Settings.cs
+++ b/OpenTabletDriver/Settings.cs
@@ -13,7 +13,7 @@ namespace OpenTabletDriver
         {
         }
 
-        private float _dW, _dH, _dX, _dY, _dR, _tW, _tH, _tX, _tY, _tR, _xsens, _ysens;
+        private float _dW, _dH, _dX, _dY, _dR, _tW, _tH, _tX, _tY, _tR, _xsens, _ysens, _tRatio, _dRatio;
         private bool _clipping, _autohook, _lockar, _sizeChanging;
         private string _theme, _outputMode;
         private TimeSpan _resetTime;
@@ -61,6 +61,7 @@ namespace OpenTabletDriver
                 this.RaiseAndSetIfChanged(ref _dW, value);
                 if (LockAspectRatio)
                     TabletHeight = DisplayHeight / DisplayWidth * TabletWidth;
+                DisplayRatio = DisplayWidth / DisplayHeight;
             }
             get => _dW;
         }
@@ -73,8 +74,16 @@ namespace OpenTabletDriver
                 this.RaiseAndSetIfChanged(ref _dH, value);
                 if (LockAspectRatio)
                     TabletWidth = DisplayWidth / DisplayHeight * TabletHeight;
+                DisplayRatio = DisplayWidth / DisplayHeight;
+                
             }
             get => _dH;
+        }
+
+        public float DisplayRatio
+        {
+            set => this.RaiseAndSetIfChanged(ref _dRatio, value);
+            get => (float)Math.Round(_dRatio * 1000f) / 1000f;
         }
 
         [JsonProperty("DisplayXOffset")]
@@ -110,6 +119,7 @@ namespace OpenTabletDriver
                     TabletHeight = DisplayHeight / DisplayWidth * value;
                     _sizeChanging = false;
                 }
+                TabletRatio = TabletWidth / TabletHeight;
             }
             get => _tW;
         }
@@ -126,8 +136,15 @@ namespace OpenTabletDriver
                     TabletWidth = DisplayWidth / DisplayHeight * value;
                     _sizeChanging = false;
                 }
+                TabletRatio = TabletWidth / TabletHeight;
             }
             get => _tH;
+        }
+
+        public float TabletRatio
+        {
+            set => this.RaiseAndSetIfChanged(ref _tRatio, value);
+            get => (float)Math.Round(_tRatio * 1000f) / 1000f;
         }
 
         [JsonProperty("TabletXOffset")]

--- a/OpenTabletDriver/Windows/MainWindow.xaml
+++ b/OpenTabletDriver/Windows/MainWindow.xaml
@@ -134,7 +134,7 @@
                                 <CheckBox Content="Lock aspect ratio" IsChecked="{Binding Settings.LockAspectRatio}"
                                     ToolTip.Tip="Locks all areas to the same aspect ratio."/>
                                 <TextBlock Text="{Binding Path=Settings.DisplayRatio, StringFormat=Display \{0\}:1}" Margin="300,1,0,0"/>
-                                <Grid Background="#6cc4e4" Height="20" Width="2" VerticalAlignment="Center" Margin="10,0,0,0"/>
+                                <Grid Background="{DynamicResource ThemeAccentBrush2}" Height="20" Width="2" VerticalAlignment="Center" Margin="10,0,0,0"/>
                                 <TextBlock Text="{Binding Path=Settings.TabletRatio, StringFormat=Tablet \{0\}:1}" Margin="10,1,0,0"/>
                             </StackPanel>
                         </Border>

--- a/OpenTabletDriver/Windows/MainWindow.xaml
+++ b/OpenTabletDriver/Windows/MainWindow.xaml
@@ -121,22 +121,26 @@
                             BackgroundWidth="{Binding Tablet.Width}"
                             BackgroundHeight="{Binding Tablet.Height}"/>
                         <Border Classes="r" Grid.Row="2" Grid.ColumnSpan="2" Margin="5">
-                            <StackPanel Orientation="Horizontal" Margin="5">
-                                <StackPanel.Styles>
-                                    <Style Selector="CheckBox">
-                                        <Setter Property="Margin" Value="0,0,5,0"/>
-                                    </Style>
-                                </StackPanel.Styles>
-                                <CheckBox Content="Enable on startup" IsChecked="{Binding Settings.AutoHook}"
-                                    ToolTip.Tip="Enables the driver as soon as the tablet is detected."/>
-                                <CheckBox Content="Area clipping" IsChecked="{Binding Settings.EnableClipping}"
-                                    ToolTip.Tip="Locks your pen inputs within the areas you set."/>
-                                <CheckBox Content="Lock aspect ratio" IsChecked="{Binding Settings.LockAspectRatio}"
-                                    ToolTip.Tip="Locks all areas to the same aspect ratio."/>
-                                <TextBlock Text="{Binding Path=Settings.DisplayRatio, StringFormat=Display \{0\}:1}" Margin="300,1,0,0"/>
-                                <Grid Background="{DynamicResource ThemeAccentBrush2}" Height="20" Width="2" VerticalAlignment="Center" Margin="10,0,0,0"/>
-                                <TextBlock Text="{Binding Path=Settings.TabletRatio, StringFormat=Tablet \{0\}:1}" Margin="10,1,0,0"/>
-                            </StackPanel>
+                            <Grid>
+                                <StackPanel HorizontalAlignment="Left" Orientation="Horizontal" Margin="5">
+                                    <StackPanel.Styles>
+                                        <Style Selector="CheckBox">
+                                            <Setter Property="Margin" Value="0,0,5,0"/>
+                                        </Style>
+                                    </StackPanel.Styles>
+                                    <CheckBox Content="Enable on startup" IsChecked="{Binding Settings.AutoHook}"
+                                        ToolTip.Tip="Enables the driver as soon as the tablet is detected."/>
+                                    <CheckBox Content="Area clipping" IsChecked="{Binding Settings.EnableClipping}"
+                                        ToolTip.Tip="Locks your pen inputs within the areas you set."/>
+                                    <CheckBox Content="Lock aspect ratio" IsChecked="{Binding Settings.LockAspectRatio}"
+                                        ToolTip.Tip="Locks all areas to the same aspect ratio."/>
+                                </StackPanel>
+                                <StackPanel HorizontalAlignment="Right" Orientation="Horizontal" Margin="5">
+                                    <TextBlock Text="{Binding Path=Settings.DisplayRatio, StringFormat=Display \{0\}:1}" VerticalAlignment="Center"/>
+                                    <Grid Background="{DynamicResource ThemeAccentBrush2}" Height="20" Width="2" VerticalAlignment="Center" Margin="10,0"/>
+                                    <TextBlock Text="{Binding Path=Settings.TabletRatio, StringFormat=Tablet \{0\}:1}" VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </Grid>
                         </Border>
                     </Grid>
                 </Border>

--- a/OpenTabletDriver/Windows/MainWindow.xaml
+++ b/OpenTabletDriver/Windows/MainWindow.xaml
@@ -133,6 +133,9 @@
                                     ToolTip.Tip="Locks your pen inputs within the areas you set."/>
                                 <CheckBox Content="Lock aspect ratio" IsChecked="{Binding Settings.LockAspectRatio}"
                                     ToolTip.Tip="Locks all areas to the same aspect ratio."/>
+                                <TextBlock Text="{Binding Path=Settings.DisplayRatio, StringFormat=Display \{0\}:1}" Margin="300,1,0,0"/>
+                                <Grid Background="#6cc4e4" Height="20" Width="2" VerticalAlignment="Center" Margin="10,0,0,0"/>
+                                <TextBlock Text="{Binding Path=Settings.TabletRatio, StringFormat=Tablet \{0\}:1}" Margin="10,1,0,0"/>
                             </StackPanel>
                         </Border>
                     </Grid>


### PR DESCRIPTION
It will update the ratio as you change the size of each area. In case the variables could be placed somewhere else please tell, is my first time going through this code.

![otd-ratio](https://user-images.githubusercontent.com/16492112/82389581-daee7f80-9a3c-11ea-8ae7-c357760bfa8b.png)
