### PR TITLE
Log the proper string format

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -17,10 +17,9 @@ jobs:
         dotnet-version: 3.1.103
     - name: Linux Publish
       run: |
-        GIT_HASH=$(git rev-parse --short $GITHUB_SHA)
-        dotnet publish OpenTabletDriver.UX.Gtk/OpenTabletDriver.UX.Gtk.csproj --configuration Release --runtime linux-x64 --framework netcoreapp3.1 --version-suffix "$GIT_HASH"
-        dotnet publish OpenTabletDriver.Daemon/OpenTabletDriver.Daemon.csproj --configuration Release --runtime linux-x64 --framework netcoreapp3.1 --version-suffix "$GIT_HASH"
-        dotnet publish OpenTabletDriver.Console/OpenTabletDriver.Console.csproj --configuration Release --runtime linux-x64 --framework netcoreapp3.1 --version-suffix "$GIT_HASH"
+        dotnet publish OpenTabletDriver.UX.Gtk/OpenTabletDriver.UX.Gtk.csproj --configuration Release --runtime linux-x64 --framework netcoreapp3.1
+        dotnet publish OpenTabletDriver.Daemon/OpenTabletDriver.Daemon.csproj --configuration Release --runtime linux-x64 --framework netcoreapp3.1
+        dotnet publish OpenTabletDriver.Console/OpenTabletDriver.Console.csproj --configuration Release --runtime linux-x64 --framework netcoreapp3.1
     - name: Copy configurations
       run: |
         cp -vr ./TabletDriverLib/Configurations/ ./OpenTabletDriver.Daemon/bin/Release/netcoreapp3.1/linux-x64/publish
@@ -41,10 +40,9 @@ jobs:
           dotnet-version: 3.1.103
       - name: Windows Publish
         run: |
-          $GIT_HASH = $(git rev-parse --short ${ENV:GITHUB_SHA})
-          dotnet publish OpenTabletDriver.UX.Wpf/OpenTabletDriver.UX.Wpf.csproj --configuration Release --runtime win-x64 --framework netcoreapp3.1 --version-suffix "$GIT_HASH"
-          dotnet publish OpenTabletDriver.Daemon/OpenTabletDriver.Daemon.csproj --configuration Release --runtime win-x64 --framework netcoreapp3.1 --version-suffix "$GIT_HASH"
-          dotnet publish OpenTabletDriver.Console/OpenTabletDriver.Console.csproj --configuration Release --runtime win-x64 --framework netcoreapp3.1 --version-suffix "$GIT_HASH"
+          dotnet publish OpenTabletDriver.UX.Wpf/OpenTabletDriver.UX.Wpf.csproj --configuration Release --runtime win-x64 --framework netcoreapp3.1
+          dotnet publish OpenTabletDriver.Daemon/OpenTabletDriver.Daemon.csproj --configuration Release --runtime win-x64 --framework netcoreapp3.1
+          dotnet publish OpenTabletDriver.Console/OpenTabletDriver.Console.csproj --configuration Release --runtime win-x64 --framework netcoreapp3.1
       - name: Copy configurations
         run: Copy-Item -Path "./TabletDriverLib/Configurations/" -Destination "./OpenTabletDriver.Daemon/bin/Release/netcoreapp3.1/win-x64/publish/Configurations/" -Recurse
       - name: Upload Windows artifacts

--- a/TabletDriverPlugin/Log.cs
+++ b/TabletDriverPlugin/Log.cs
@@ -12,7 +12,7 @@ namespace TabletDriverPlugin
         private static void Post(LogMessage message)
         {
             Output?.Invoke(null, message);
-            Console.WriteLine(string.Format("[{0}:{1}]\t{2}", message.IsError ? "Error" : "Normal", message.Group, message.Message));
+            Console.WriteLine(GetStringFormat(message));
         }
 
         public static string GetStringFormat(LogMessage message)


### PR DESCRIPTION
# Changes
- [x] Uses the `GetStringFormat()` method to format console output
  > This should now include stack traces in the output.