### PR TITLE
FIX: Opening URLs with spaces would return an error

### DIFF
--- a/NativeLib/Tools.cs
+++ b/NativeLib/Tools.cs
@@ -9,7 +9,7 @@ namespace NativeLib
         {
             if (PlatformInfo.IsWindows)
             {
-                var startInfo = new ProcessStartInfo("cmd", $"/c start {url.Replace("&", "^&")}")
+                var startInfo = new ProcessStartInfo("cmd", $"/c start \"\" \"{url.Replace("&", "^&")}\"")
                 {
                     CreateNoWindow = true
                 };


### PR DESCRIPTION
This fixes the issue where if the user had 2 words in their name, that are spaced out (ex: C:\Users\Jack Smith\...), it would attempt to open a non existent directory (C:\Users\Jack)

![image](https://user-images.githubusercontent.com/18307183/86577393-00711300-bf2f-11ea-8618-bb4f18c7d4d1.png)



