### PR TITLE
Add OutputInitReport and G640 v2 firmware config

### DIFF
--- a/OpenTabletDriver.UX/Windows/ConfigurationEditor.cs
+++ b/OpenTabletDriver.UX/Windows/ConfigurationEditor.cs
@@ -320,6 +320,25 @@ namespace OpenTabletDriver.UX.Windows
                         SelectedConfiguration.FeatureInitReport = buffer;
                     }
                 ),
+                GetControl("Output Initialization Report", 
+                    () => SelectedConfiguration.OutputInitReport != null ? ToHexValue(SelectedConfiguration.OutputInitReport) : string.Empty,
+                    (o) => 
+                    {
+                        var raw = o.Split(' ');
+                        byte[] buffer = new byte[raw.Length];
+                        for (int i = 0; i < raw.Length; i++)
+                        {
+                            if (TryGetHexValue(raw[i], out var val))
+                                buffer[i] = val;
+                            else
+                            {
+                                SelectedConfiguration.OutputInitReport = null;
+                                return;
+                            }
+                        }
+                        SelectedConfiguration.OutputInitReport = buffer;
+                    }
+                )
             };
 
         private GroupBox GetControl(string groupName, Func<string> getValue, Action<string> setValue, string placeholder = null)

--- a/TabletDriverLib/Configurations/XP-Pen/G640 v2 Firmware Patch.json
+++ b/TabletDriverLib/Configurations/XP-Pen/G640 v2 Firmware Patch.json
@@ -1,0 +1,20 @@
+{
+    "Name": "XP-Pen G640 v2 (Firmware Patch)",
+    "VendorID": 10429,
+    "ProductID": 2324,
+    "InputReportLength": 12,
+    "OutputReportLength": 0,
+    "ReportParser": null,
+    "CustomInputReportLength": 0,
+    "CustomReportParser": null,
+    "Width": 160.0,
+    "Height": 100.0,
+    "MaxX": 32000.0,
+    "MaxY": 20000.0,
+    "MaxPressure": 8191,
+    "ActiveReportID": 64,
+    "AuxReportLength": 0,
+    "AuxReportParser": null,
+    "FeatureInitReport": null,
+    "OutputInitReport": "ArAEAAAAAAAAAAAA"
+  }

--- a/TabletDriverLib/Driver.cs
+++ b/TabletDriverLib/Driver.cs
@@ -163,8 +163,14 @@ namespace TabletDriverLib
             
             if (TabletProperties.FeatureInitReport != null && TabletProperties.FeatureInitReport.Length > 0)
             {
-                Log.Debug($"Setting feature: " + BitConverter.ToString(TabletProperties.FeatureInitReport));
+                Log.Debug("Setting feature: " + BitConverter.ToString(TabletProperties.FeatureInitReport));
                 TabletReader.ReportStream.SetFeature(TabletProperties.FeatureInitReport);
+            }
+
+            if (TabletProperties.OutputInitReport != null && TabletProperties.OutputInitReport.Length > 0)
+            {
+                Log.Debug("Setting output: " + BitConverter.ToString(TabletProperties.OutputInitReport));
+                TabletReader.ReportStream.Write(TabletProperties.OutputInitReport);
             }
         }
 

--- a/TabletDriverPlugin/Tablet/TabletProperties.cs
+++ b/TabletDriverPlugin/Tablet/TabletProperties.cs
@@ -9,7 +9,7 @@ namespace TabletDriverPlugin.Tablet
         private int _vid, _pid;
         private uint _inputReportLength, _customInputReportLength, _reportId, _auxReportLength, _outputReportLength, _maxPressure;
         private float _width, _height, _maxX, _maxY;
-        private byte[] _featureInitReport;
+        private byte[] _featureInitReport, _outputInitReport;
 
         /// <summary>
         /// The device's name.
@@ -197,6 +197,13 @@ namespace TabletDriverPlugin.Tablet
         {
             set => this.RaiseAndSetIfChanged(ref _featureInitReport, value);
             get => _featureInitReport;
+        }
+        
+        [JsonProperty("OutputInitReport")]
+        public byte[] OutputInitReport
+        {
+            set => this.RaiseAndSetIfChanged(ref _outputInitReport, value);
+            get => _outputInitReport;
         }
 
         #region Json Serialization


### PR DESCRIPTION
# Changes
- [x] Add OutputInitReport tablet property
  - Used to initialize tablets via the output stream
- [x] Add support for the G640 v2 with modified firmware