### PR TITLE
Add Wayland display support

### DIFF
--- a/TabletDriverLib/Interop/Display/WaylandDisplay.cs
+++ b/TabletDriverLib/Interop/Display/WaylandDisplay.cs
@@ -69,13 +69,13 @@ namespace TabletDriverLib.Interop.Display
             switch (@interface)
             {
                 case "wl_output":
-                    var wlOutput = wlRegistry.Bind<WlOutput>(name, @interface, 3);
+                    var wlOutput = wlRegistry.Bind<WlOutput>(name, @interface, 1);
                     var output = new WaylandOutput(wlOutput, _outputs.Count + 1);
                     output.WlOutput.Listener = output;
                     _outputs.Add(output);
                     break;
                 case "zxdg_output_manager_v1":
-                    _outputManager = wlRegistry.Bind<ZxdgOutputManagerV1>(name, @interface, 3);
+                    _outputManager = wlRegistry.Bind<ZxdgOutputManagerV1>(name, @interface, Math.Min(version, 2));
                     break;
             }
         }

--- a/TabletDriverLib/Interop/Display/WaylandDisplay.cs
+++ b/TabletDriverLib/Interop/Display/WaylandDisplay.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using TabletDriverPlugin;
+using TabletDriverPlugin.Platform.Display;
+using WaylandNET.Client;
+using WaylandNET.Client.Protocol;
+
+namespace TabletDriverLib.Interop.Display
+{
+    public class WaylandDisplay : IVirtualScreen, WlRegistry.IListener
+    {
+        private List<WaylandOutput> _outputs;
+        private ZxdgOutputManagerV1 _outputManager;
+
+        public WaylandDisplay()
+        {
+            _outputs = new List<WaylandOutput>();
+            using (var connection = new WaylandClientConnection())
+            {
+                var registry = connection.Display.GetRegistry();
+                registry.Listener = this;
+                connection.Roundtrip();
+                if (_outputManager != null)
+                {
+                    foreach (var output in _outputs)
+                    {
+                        output.XdgOutput = _outputManager.GetXdgOutput(output.WlOutput);
+                        output.XdgOutput.Listener = output;
+                    }
+                }
+                connection.Roundtrip();
+            }
+        }
+
+        public IEnumerable<IDisplay> Displays => new IDisplay[] { this }.Concat(_outputs);
+
+        public int Index => 0;
+
+        public float Width
+        {
+            get
+            {
+                var left = _outputs.Min(d => d.Position.X);
+                var right = _outputs.Max(d => d.Position.X + d.Width);
+                return right - left;
+            }
+        }
+
+        public float Height
+        {
+            get
+            {
+                var top = _outputs.Min(d => d.Position.Y);
+                var bottom = _outputs.Max(d => d.Position.Y + d.Height);
+                return bottom - top;
+            }
+        }
+
+        public Point Position => new Point(0, 0);
+
+        public override string ToString()
+        {
+            return $"Virtual Display ({Width}x{Height}@{Position})";
+        }
+
+        void WlRegistry.IListener.Global(WlRegistry wlRegistry, uint name, string @interface, uint version)
+        {
+            switch (@interface)
+            {
+                case "wl_output":
+                    var wlOutput = wlRegistry.Bind<WlOutput>(name, @interface, 3);
+                    var output = new WaylandOutput(wlOutput, _outputs.Count + 1);
+                    output.WlOutput.Listener = output;
+                    _outputs.Add(output);
+                    break;
+                case "zxdg_output_manager_v1":
+                    _outputManager = wlRegistry.Bind<ZxdgOutputManagerV1>(name, @interface, 3);
+                    break;
+            }
+        }
+
+        void WlRegistry.IListener.GlobalRemove(WlRegistry wlRegistry, uint name)
+        {
+        }
+    }
+}

--- a/TabletDriverLib/Interop/Display/WaylandOutput.cs
+++ b/TabletDriverLib/Interop/Display/WaylandOutput.cs
@@ -1,0 +1,83 @@
+using TabletDriverPlugin;
+using TabletDriverPlugin.Platform.Display;
+using WaylandNET.Client.Protocol;
+
+namespace TabletDriverLib.Interop.Display
+{
+    public class WaylandOutput : IDisplay, WlOutput.IListener, ZxdgOutputV1.IListener
+    {
+        public WlOutput WlOutput { private set; get; }
+        public ZxdgOutputV1 XdgOutput { set; get; }
+
+        public int Index { private set; get; }
+        public float Width { private set; get; }
+        public float Height { private set; get; }
+        public Point Position { private set; get; }
+
+        private string _name, _description;
+
+        public WaylandOutput(WlOutput wlOutput, int index)
+        {
+            WlOutput = wlOutput;
+            Index = index;
+        }
+
+        public override string ToString()
+        {
+            return $"{_name} {_description} ({Width}x{Height}@{Position})";
+        }
+
+        void WlOutput.IListener.Geometry(WlOutput wlOutput, int x, int y, int physicalWidth, int physicalHeight,
+            WlOutput.Subpixel subpixel, string make, string model, WlOutput.Transform transform)
+        {
+            if (XdgOutput == null)
+            {
+                Position = new Point(x, y);
+                _name = make;
+                _description = model;
+            }
+        }
+
+        void WlOutput.IListener.Mode(WlOutput wlOutput, WlOutput.Mode flags, int width, int height, int refresh)
+        {
+            if (XdgOutput == null && flags.HasFlag(WlOutput.Mode.Current))
+            {
+                Width = width;
+                Height = height;
+            }
+        }
+
+        void WlOutput.IListener.Done(WlOutput wlOutput)
+        {
+        }
+
+        void WlOutput.IListener.Scale(WlOutput wlOutput, int factor)
+        {
+        }
+
+        void ZxdgOutputV1.IListener.LogicalPosition(ZxdgOutputV1 zxdgOutputV1, int x, int y)
+        {
+            Position = new Point(x, y);
+        }
+
+        void ZxdgOutputV1.IListener.LogicalSize(ZxdgOutputV1 zxdgOutputV1, int width, int height)
+        {
+            Width = width;
+            Height = height;
+        }
+
+        void ZxdgOutputV1.IListener.Done(ZxdgOutputV1 zxdgOutputV1)
+        {
+        }
+
+        void ZxdgOutputV1.IListener.Name(ZxdgOutputV1 zxdgOutputV1, string name)
+        {
+            _name = name;
+        }
+
+        void ZxdgOutputV1.IListener.Description(ZxdgOutputV1 zxdgOutputV1, string description)
+        {
+            _description = description;
+        }
+    }
+}

--- a/TabletDriverLib/Interop/Display/WaylandOutput.cs
+++ b/TabletDriverLib/Interop/Display/WaylandOutput.cs
@@ -31,7 +31,8 @@ namespace TabletDriverLib.Interop.Display
         void WlOutput.IListener.Geometry(WlOutput wlOutput, int x, int y, int physicalWidth, int physicalHeight,
             WlOutput.Subpixel subpixel, string make, string model, WlOutput.Transform transform)
         {
-            if (XdgOutput == null)
+            // xdg_output version 1 does not have name or description events
+            if (XdgOutput == null || XdgOutput.Version < 2)
             {
                 Position = new Point(x, y);
                 Name = make;

--- a/TabletDriverLib/Interop/Display/WaylandOutput.cs
+++ b/TabletDriverLib/Interop/Display/WaylandOutput.cs
@@ -14,7 +14,8 @@ namespace TabletDriverLib.Interop.Display
         public float Height { private set; get; }
         public Point Position { private set; get; }
 
-        private string _name, _description;
+        public string Name { private set; get; }
+        public string Description { private set; get; }
 
         public WaylandOutput(WlOutput wlOutput, int index)
         {
@@ -24,7 +25,7 @@ namespace TabletDriverLib.Interop.Display
 
         public override string ToString()
         {
-            return $"{_name} {_description} ({Width}x{Height}@{Position})";
+            return $"{Name} {Description} ({Width}x{Height}@{Position})";
         }
 
         void WlOutput.IListener.Geometry(WlOutput wlOutput, int x, int y, int physicalWidth, int physicalHeight,
@@ -33,8 +34,8 @@ namespace TabletDriverLib.Interop.Display
             if (XdgOutput == null)
             {
                 Position = new Point(x, y);
-                _name = make;
-                _description = model;
+                Name = make;
+                Description = model;
             }
         }
 
@@ -72,12 +73,12 @@ namespace TabletDriverLib.Interop.Display
 
         void ZxdgOutputV1.IListener.Name(ZxdgOutputV1 zxdgOutputV1, string name)
         {
-            _name = name;
+            Name = name;
         }
 
         void ZxdgOutputV1.IListener.Description(ZxdgOutputV1 zxdgOutputV1, string description)
         {
-            _description = description;
+            Description = description;
         }
     }
 }

--- a/TabletDriverLib/Interop/Platform.cs
+++ b/TabletDriverLib/Interop/Platform.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Net.Sockets;
 using NativeLib;
 using TabletDriverLib.Interop.Cursor;
 using TabletDriverLib.Interop.Display;

--- a/TabletDriverLib/Interop/Platform.cs
+++ b/TabletDriverLib/Interop/Platform.cs
@@ -38,18 +38,6 @@ namespace TabletDriverLib.Interop
             };
         });
 
-        private static IVirtualScreen GetLinuxScreen()
-        {
-            try
-            {
-                return new WaylandDisplay();
-            }
-            catch (SocketException)
-            {
-                return new XScreen();
-            }
-        }
-
         private static Lazy<IVirtualScreen> _virtualScreen = new Lazy<IVirtualScreen>(() => 
         {
             return SystemInfo.CurrentPlatform switch
@@ -60,5 +48,15 @@ namespace TabletDriverLib.Interop
                 _                       => null
             };
         });
+
+        private static IVirtualScreen GetLinuxScreen()
+        {
+            if (Environment.GetEnvironmentVariable("WAYLAND_DISPLAY") != null)
+                return new WaylandDisplay();
+            else if (Environment.GetEnvironmentVariable("DISPLAY") != null)
+                return new XScreen();
+            else
+                throw new Exception("Neither Wayland nor X11 were detected. Make sure DISPLAY or WAYLAND_DISPLAY is set.");
+        }
     }
 }

--- a/TabletDriverLib/Interop/Platform.cs
+++ b/TabletDriverLib/Interop/Platform.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net.Sockets;
 using NativeLib;
 using TabletDriverLib.Interop.Cursor;
 using TabletDriverLib.Interop.Display;
@@ -37,12 +38,24 @@ namespace TabletDriverLib.Interop
             };
         });
 
+        private static IVirtualScreen GetLinuxScreen()
+        {
+            try
+            {
+                return new WaylandDisplay();
+            }
+            catch (SocketException)
+            {
+                return new XScreen();
+            }
+        }
+
         private static Lazy<IVirtualScreen> _virtualScreen = new Lazy<IVirtualScreen>(() => 
         {
             return SystemInfo.CurrentPlatform switch
             {
                 RuntimePlatform.Windows => new WindowsDisplay(),
-                RuntimePlatform.Linux   => new XScreen(),
+                RuntimePlatform.Linux   => GetLinuxScreen(),
                 RuntimePlatform.MacOS   => new MacOSDisplay(),
                 _                       => null
             };

--- a/TabletDriverLib/TabletDriverLib.csproj
+++ b/TabletDriverLib/TabletDriverLib.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="HidSharpCore" Version="1.0.0" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
+    <PackageReference Include="WaylandNET" Version="0.1.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This allows talking to Wayland compositors directly, rather than relying
on XWayland data which often doesn't reflect the exact setup on Wayland,
and of course doesn't work without XWayland running.

It tries to use xdg_output for precise data, but falls back to wl_output
information if that protocol is missing.