### PR TITLE
Interop.Display: Update to WaylandNET 0.2.0

### DIFF
--- a/TabletDriverLib/Interop/Display/WaylandOutput.cs
+++ b/TabletDriverLib/Interop/Display/WaylandOutput.cs
@@ -4,82 +4,18 @@ using WaylandNET.Client.Protocol;
 
 namespace TabletDriverLib.Interop.Display
 {
-    public class WaylandOutput : IDisplay, WlOutput.IListener, ZxdgOutputV1.IListener
+    public class WaylandOutput : IDisplay
     {
-        public WlOutput WlOutput { private set; get; }
-        public ZxdgOutputV1 XdgOutput { set; get; }
+        internal WlOutput WlOutput { set; get; }
+        internal ZxdgOutputV1 XdgOutput { set; get; }
 
-        public int Index { private set; get; }
-        public float Width { private set; get; }
-        public float Height { private set; get; }
-        public Point Position { private set; get; }
+        public int Index { set; get; }
+        public float Width { set; get; }
+        public float Height { set; get; }
+        public Point Position { set; get; }
+        public string Name { set; get; }
+        public string Description { set; get; }
 
-        public string Name { private set; get; }
-        public string Description { private set; get; }
-
-        public WaylandOutput(WlOutput wlOutput, int index)
-        {
-            WlOutput = wlOutput;
-            Index = index;
-        }
-
-        public override string ToString()
-        {
-            return $"{Name} {Description} ({Width}x{Height}@{Position})";
-        }
-
-        void WlOutput.IListener.Geometry(WlOutput wlOutput, int x, int y, int physicalWidth, int physicalHeight,
-            WlOutput.Subpixel subpixel, string make, string model, WlOutput.Transform transform)
-        {
-            // xdg_output version 1 does not have name or description events
-            if (XdgOutput == null || XdgOutput.Version < 2)
-            {
-                Position = new Point(x, y);
-                Name = make;
-                Description = model;
-            }
-        }
-
-        void WlOutput.IListener.Mode(WlOutput wlOutput, WlOutput.Mode flags, int width, int height, int refresh)
-        {
-            if (XdgOutput == null && flags.HasFlag(WlOutput.Mode.Current))
-            {
-                Width = width;
-                Height = height;
-            }
-        }
-
-        void WlOutput.IListener.Done(WlOutput wlOutput)
-        {
-        }
-
-        void WlOutput.IListener.Scale(WlOutput wlOutput, int factor)
-        {
-        }
-
-        void ZxdgOutputV1.IListener.LogicalPosition(ZxdgOutputV1 zxdgOutputV1, int x, int y)
-        {
-            Position = new Point(x, y);
-        }
-
-        void ZxdgOutputV1.IListener.LogicalSize(ZxdgOutputV1 zxdgOutputV1, int width, int height)
-        {
-            Width = width;
-            Height = height;
-        }
-
-        void ZxdgOutputV1.IListener.Done(ZxdgOutputV1 zxdgOutputV1)
-        {
-        }
-
-        void ZxdgOutputV1.IListener.Name(ZxdgOutputV1 zxdgOutputV1, string name)
-        {
-            Name = name;
-        }
-
-        void ZxdgOutputV1.IListener.Description(ZxdgOutputV1 zxdgOutputV1, string description)
-        {
-            Description = description;
-        }
+        public override string ToString() => $"{Name} {Description} ({Width}x{Height}@{Position})";
     }
 }

--- a/TabletDriverLib/TabletDriverLib.csproj
+++ b/TabletDriverLib/TabletDriverLib.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="HidSharpCore" Version="1.0.0" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
-    <PackageReference Include="WaylandNET" Version="0.1.0" />
+    <PackageReference Include="WaylandNET" Version="0.2.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Events are cool.

Keeping the separate WaylandDisplay class (with public fields) isn't great, but I'm not sure what to do instead.