### PR TITLE
Create parent directory when writing configs

### DIFF
--- a/OpenTabletDriver.UX/Windows/ConfigurationEditor.cs
+++ b/OpenTabletDriver.UX/Windows/ConfigurationEditor.cs
@@ -163,6 +163,8 @@ namespace OpenTabletDriver.UX.Windows
 
                 var path = Path.Join(dir.FullName, manufacturer, string.Format("{0}.json", tabletName));
                 var file = new FileInfo(path);
+                if (!file.Directory.Exists)
+                    file.Directory.Create();
                 config.Write(file);
             }
         }


### PR DESCRIPTION
# Changes
- Create parent directory when writing configurations from configuration editor
  - Handles a `DirectoryNotFoundException` when writing to an empty folder