### PR TITLE
Finally fix filter settings not getting applied

### DIFF
--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -120,22 +120,13 @@ namespace OpenTabletDriver.Daemon
 
             foreach (var filter in outputMode.Filters)
             {
-                var properties = from property in filter.GetType().GetProperties()
-                    where property.GetCustomAttribute<PropertyAttribute>(false) != null
-                    select property;
-                
-                foreach (var property in properties)
+                foreach (var property in filter.GetType().GetProperties())
                 {
-                    var properties = filter.GetType().GetProperties();
-                    
-                    foreach (var property in properties)
+                    if (property.GetCustomAttribute<PropertyAttribute>(false) != null && 
+                        Settings.PluginSettings.TryGetValue(filter.GetType().FullName + "." + property.Name, out var strValue))
                     {
-                        if (property.GetCustomAttribute<PropertyAttribute>(false) != null && 
-                            Settings.PluginSettings.TryGetValue(filter.GetType().FullName + "." + property.Name, out var strValue))
-                        {
-                            var value = Convert.ChangeType(strValue, property.PropertyType);
-                            property.SetValue(filter, value);
-                        }
+                        var value = Convert.ChangeType(strValue, property.PropertyType);
+                        property.SetValue(filter, value);
                     }
                 }
             }

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -101,13 +101,12 @@ namespace OpenTabletDriver.Daemon
 
                 foreach (var filter in outputMode.Filters)
                 {
-                    var properties = from property in filter.GetType().GetProperties()
-                        where property.GetCustomAttribute<PropertyAttribute>(false) != null
-                        select property;
+                    var properties = filter.GetType().GetProperties();
                     
                     foreach (var property in properties)
                     {
-                        if (Settings.PluginSettings.TryGetValue(property.Name, out var strValue))
+                        if (property.GetCustomAttribute<PropertyAttribute>(false) != null && 
+                            Settings.PluginSettings.TryGetValue(filter.GetType().FullName + "." + property.Name, out var strValue))
                         {
                             var value = Convert.ChangeType(strValue, property.PropertyType);
                             property.SetValue(filter, value);

--- a/TabletDriverPlugin/Output/AbsoluteOutputMode.cs
+++ b/TabletDriverPlugin/Output/AbsoluteOutputMode.cs
@@ -14,15 +14,12 @@ namespace TabletDriverPlugin.Output
         private float _halfDisplayWidth, _halfDisplayHeight, _halfTabletWidth, _halfTabletHeight;
         private float _minX, _maxX, _minY, _maxY;
 
-        private IEnumerable<IFilter> _filters;
-        private List<IFilter> _preFilters, _postFilters;
+        private List<IFilter> _filters;
         public IEnumerable<IFilter> Filters
         {
             set
             {
-                _filters = value;
-                _preFilters = value.Where(f => f.FilterStage == FilterStage.PreTranspose).ToList();
-                _postFilters = value.Where(f => f.FilterStage == FilterStage.PostTranspose).ToList();
+                _filters = value.ToList();
             }
             get => _filters;
         }
@@ -100,8 +97,9 @@ namespace TabletDriverPlugin.Output
             var pos = new Point(report.Position.X, report.Position.Y);
 
             // Pre Filter
-            foreach (IFilter filter in _preFilters)
-                pos = filter.Filter(pos);
+            foreach (IFilter filter in _filters)
+                if (filter.FilterStage == FilterStage.PreTranspose)
+                    pos = filter.Filter(pos);
 
             // Normalize (ratio of 1)
             pos.X /= TabletProperties.MaxX;
@@ -152,8 +150,9 @@ namespace TabletDriverPlugin.Output
             }
 
             // Post Filter
-            foreach (IFilter filter in _postFilters)
-                pos = filter.Filter(pos);
+            foreach (IFilter filter in _filters)
+                if (filter.FilterStage == FilterStage.PostTranspose)
+                    pos = filter.Filter(pos);
 
             return pos;
         }

--- a/TabletDriverPlugin/Output/AbsoluteOutputMode.cs
+++ b/TabletDriverPlugin/Output/AbsoluteOutputMode.cs
@@ -20,6 +20,8 @@ namespace TabletDriverPlugin.Output
             set
             {
                 _filters = value.ToList();
+                _preFilters.Clear();
+                _postFilters.Clear();
                 foreach (IFilter filter in _filters)
                     if (filter.FilterStage == FilterStage.PreTranspose)
                         _preFilters.Add(filter);

--- a/TabletDriverPlugin/Output/AbsoluteOutputMode.cs
+++ b/TabletDriverPlugin/Output/AbsoluteOutputMode.cs
@@ -14,12 +14,17 @@ namespace TabletDriverPlugin.Output
         private float _halfDisplayWidth, _halfDisplayHeight, _halfTabletWidth, _halfTabletHeight;
         private float _minX, _maxX, _minY, _maxY;
 
-        private List<IFilter> _filters;
+        private List<IFilter> _filters, _preFilters = new List<IFilter>(), _postFilters = new List<IFilter>();
         public IEnumerable<IFilter> Filters
         {
             set
             {
                 _filters = value.ToList();
+                foreach (IFilter filter in _filters)
+                    if (filter.FilterStage == FilterStage.PreTranspose)
+                        _preFilters.Add(filter);
+                    else if (filter.FilterStage == FilterStage.PostTranspose)
+                        _postFilters.Add(filter);
             }
             get => _filters;
         }
@@ -97,9 +102,8 @@ namespace TabletDriverPlugin.Output
             var pos = new Point(report.Position.X, report.Position.Y);
 
             // Pre Filter
-            foreach (IFilter filter in _filters)
-                if (filter.FilterStage == FilterStage.PreTranspose)
-                    pos = filter.Filter(pos);
+            foreach (IFilter filter in _preFilters)
+                pos = filter.Filter(pos);
 
             // Normalize (ratio of 1)
             pos.X /= TabletProperties.MaxX;
@@ -150,9 +154,8 @@ namespace TabletDriverPlugin.Output
             }
 
             // Post Filter
-            foreach (IFilter filter in _filters)
-                if (filter.FilterStage == FilterStage.PostTranspose)
-                    pos = filter.Filter(pos);
+            foreach (IFilter filter in _postFilters)
+                pos = filter.Filter(pos);
 
             return pos;
         }

--- a/TabletDriverPlugin/Output/RelativeOutputMode.cs
+++ b/TabletDriverPlugin/Output/RelativeOutputMode.cs
@@ -10,14 +10,19 @@ namespace TabletDriverPlugin.Output
     [PluginIgnore]
     public abstract class RelativeOutputMode : BindingHandler, IOutputMode
     {
-        private IEnumerable<IFilter> _filters, _preFilters, _postFilters;
+        private List<IFilter> _filters, _preFilters = new List<IFilter>(), _postFilters = new List<IFilter>();
         public IEnumerable<IFilter> Filters
         {
             set
             {
-                _filters = value;
-                _preFilters = value.Where(f => f.FilterStage == FilterStage.PreTranspose);
-                _postFilters = value.Where(f => f.FilterStage == FilterStage.PostTranspose);
+                _filters = value.ToList();
+                _preFilters.Clear();
+                _postFilters.Clear();
+                foreach (IFilter filter in _filters)
+                    if (filter.FilterStage == FilterStage.PreTranspose)
+                        _preFilters.Add(filter);
+                    else if (filter.FilterStage == FilterStage.PostTranspose)
+                        _postFilters.Add(filter);
             }
             get => _filters;
         }


### PR DESCRIPTION
There were two problems, the incomplete name when querying the PluginSetting dictionary, and the filter being reconstructed (yeah, it was actually just half-fixed)

Now the filters are only constructed once, instead of three times.