### PR TITLE
Fix plugin dependency not loading in shared context

### DIFF
--- a/TabletDriverLib/PluginManager.cs
+++ b/TabletDriverLib/PluginManager.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.Loader;
 using System.Threading.Tasks;
 using NativeLib;
 using TabletDriverPlugin;
@@ -46,7 +47,7 @@ namespace TabletDriverLib
 
         private static async Task<Assembly> ImportAssembly(string path)
         {
-            return await Task.Run<Assembly>(() => Assembly.LoadFile(path));
+            return await Task.Run<Assembly>(() => AssemblyLoadContext.Default.LoadFromAssemblyPath(path));
         }
 
         private static IEnumerable<Type> GetLoadableTypes(Assembly asm)


### PR DESCRIPTION
Might introduce problems since plugins aren't isolated anymore. I tried creating a custom AssemblyLoadContext for isolation and dependency resolution, but it became too isolated that interfaces didn't work anymore (casting does not work).