### PR TITLE
Update IPC framework version

### DIFF
--- a/OpenTabletDriver.Console/OpenTabletDriver.Console.csproj
+++ b/OpenTabletDriver.Console/OpenTabletDriver.Console.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20303.1" />
-    <PackageReference Include="JKang.IpcServiceFramework.Client.NamedPipe" Version="3.0.2" />
+    <PackageReference Include="JKang.IpcServiceFramework.Client.NamedPipe" Version="3.0.4" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.5" />
     <ProjectReference Include="..\TabletDriverLib\TabletDriverLib.csproj" />
   </ItemGroup>

--- a/OpenTabletDriver.Daemon/OpenTabletDriver.Daemon.csproj
+++ b/OpenTabletDriver.Daemon/OpenTabletDriver.Daemon.csproj
@@ -5,8 +5,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="JKang.IpcServiceFramework.Client.NamedPipe" Version="3.0.2" />
-    <PackageReference Include="JKang.IpcServiceFramework.Hosting.NamedPipe" Version="3.0.0.28-alpha" />
+    <PackageReference Include="JKang.IpcServiceFramework.Hosting.NamedPipe" Version="3.0.4" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.5" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="3.1.5" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20253.1" />

--- a/OpenTabletDriver.UX/OpenTabletDriver.UX.csproj
+++ b/OpenTabletDriver.UX/OpenTabletDriver.UX.csproj
@@ -12,7 +12,7 @@
   
   <ItemGroup>
     <PackageReference Include="Eto.Forms" Version="2.5.2" />
-    <PackageReference Include="JKang.IpcServiceFramework.Client.NamedPipe" Version="3.0.2" />
+    <PackageReference Include="JKang.IpcServiceFramework.Client.NamedPipe" Version="3.0.4" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.5" />
     <ProjectReference Include="..\TabletDriverLib\TabletDriverLib.csproj" />
   </ItemGroup>


### PR DESCRIPTION
# Changes
- Updated IPC framework version (3.0.2 -> 3.0.4)
  - Fixes macOS crashes
- Removed unnecessary reference to Client framework in Daemon host
