### PR TITLE
Use ranges removing unnecessary array creation

### DIFF
--- a/TabletDriverLib/Vendors/SkipByteTabletReportParser.cs
+++ b/TabletDriverLib/Vendors/SkipByteTabletReportParser.cs
@@ -8,7 +8,7 @@ namespace TabletDriverLib.Vendors
     {
         public override IDeviceReport Parse(byte[] data)
         {
-            return base.Parse(data.Skip(1).ToArray());
+            return base.Parse(data[1..^0]);
         }
     }
 }

--- a/TabletDriverLib/Vendors/Wacom/WacomDriverIntuosV2ReportParser.cs
+++ b/TabletDriverLib/Vendors/Wacom/WacomDriverIntuosV2ReportParser.cs
@@ -7,7 +7,7 @@ namespace TabletDriverLib.Vendors.Wacom
     {
         public override IDeviceReport Parse(byte[] data)
         {
-            return base.Parse(data.Skip(1).ToArray());
+            return base.Parse(data[1..^0]);
         }
     }
 }


### PR DESCRIPTION
# Changes
- Use array range to index the "skip first byte" parsers
  - Removes unnecessary array creation