### PR TITLE
Add IntuosV3 support

### DIFF
--- a/TabletDriverLib/Configurations/Wacom/CTL-4100 Bluetooth.json
+++ b/TabletDriverLib/Configurations/Wacom/CTL-4100 Bluetooth.json
@@ -5,16 +5,16 @@
     "ProductID": 887,
     "InputReportLength": 361,
     "OutputReportLength": 0,
-    "ReportParser": null,
+    "ReportParser": "TabletDriverLib.Vendors.Wacom.IntuosV3ReportParser",
     "FeatureInitReport": null,
     "OutputInitReport": null
   },
   "AlternateDigitizerIdentifier": {
     "VendorID": 1386,
     "ProductID": 887,
-    "InputReportLength": 0,
+    "InputReportLength": 193,
     "OutputReportLength": 0,
-    "ReportParser": null,
+    "ReportParser": "TabletDriverLib.Vendors.Wacom.WacomDriverIntuosV3ReportParser",
     "FeatureInitReport": null,
     "OutputInitReport": null
   },
@@ -33,8 +33,8 @@
   "MaxY": 9500.0,
   "MaxPressure": 4095,
   "ActiveReportID": {
-    "Start": 224,
-    "StartInclusive": false,
+    "Start": 16,
+    "StartInclusive": true,
     "End": null,
     "EndInclusive": false
   },

--- a/TabletDriverLib/Configurations/Wacom/CTL-4100.json
+++ b/TabletDriverLib/Configurations/Wacom/CTL-4100.json
@@ -5,16 +5,16 @@
     "ProductID": 884,
     "InputReportLength": 192,
     "OutputReportLength": 0,
-    "ReportParser": null,
+    "ReportParser": "TabletDriverLib.Vendors.Wacom.IntuosV3ReportParser",
     "FeatureInitReport": null,
     "OutputInitReport": null
   },
   "AlternateDigitizerIdentifier": {
     "VendorID": 1386,
     "ProductID": 884,
-    "InputReportLength": 0,
+    "InputReportLength": 193,
     "OutputReportLength": 0,
-    "ReportParser": null,
+    "ReportParser": "TabletDriverLib.Vendors.Wacom.WacomDriverIntuosV3ReportParser",
     "FeatureInitReport": null,
     "OutputInitReport": null
   },
@@ -33,8 +33,8 @@
   "MaxY": 9500.0,
   "MaxPressure": 4095,
   "ActiveReportID": {
-    "Start": 32,
-    "StartInclusive": false,
+    "Start": 16,
+    "StartInclusive": true,
     "End": null,
     "EndInclusive": false
   },

--- a/TabletDriverLib/Configurations/Wacom/CTL-6100.json
+++ b/TabletDriverLib/Configurations/Wacom/CTL-6100.json
@@ -5,7 +5,7 @@
     "ProductID": 888,
     "InputReportLength": 192,
     "OutputReportLength": 0,
-    "ReportParser": null,
+    "ReportParser": "TabletDriverLib.Vendors.Wacom.IntuosV3ReportParser",
     "FeatureInitReport": null,
     "OutputInitReport": null
   },
@@ -33,8 +33,8 @@
   "MaxY": 13500.0,
   "MaxPressure": 4095,
   "ActiveReportID": {
-    "Start": 0,
-    "StartInclusive": false,
+    "Start": 16,
+    "StartInclusive": true,
     "End": null,
     "EndInclusive": false
   },

--- a/TabletDriverLib/Configurations/Wacom/PTH-660.json
+++ b/TabletDriverLib/Configurations/Wacom/PTH-660.json
@@ -5,7 +5,7 @@
     "ProductID": 855,
     "InputReportLength": 192,
     "OutputReportLength": 0,
-    "ReportParser": null,
+    "ReportParser": "TabletDriverLib.Vendors.Wacom.IntuosV3ReportParser",
     "FeatureInitReport": null,
     "OutputInitReport": null
   },
@@ -33,8 +33,8 @@
   "MaxY": 29600.0,
   "MaxPressure": 8191,
   "ActiveReportID": {
-    "Start": 0,
-    "StartInclusive": false,
+    "Start": 16,
+    "StartInclusive": true,
     "End": null,
     "EndInclusive": false
   },

--- a/TabletDriverLib/Tablet/Extensions.cs
+++ b/TabletDriverLib/Tablet/Extensions.cs
@@ -25,7 +25,7 @@ namespace TabletDriverLib.Tablet
                 }
                 else
                 {
-                    return report.ToString();
+                    return $"Raw: {BitConverter.ToString(report.Raw).Replace('-', ' ')}";
                 }
             }
         }

--- a/TabletDriverLib/Vendors/Wacom/IntuosV3AuxReport.cs
+++ b/TabletDriverLib/Vendors/Wacom/IntuosV3AuxReport.cs
@@ -1,0 +1,23 @@
+using TabletDriverPlugin.Tablet;
+
+namespace TabletDriverLib.Vendors.Wacom
+{
+    public class IntuosV3AuxReport : IAuxReport
+    {
+        public IntuosV3AuxReport(byte[] report)
+        {
+            Raw = report;
+
+            AuxButtons = new bool[]
+            {
+                (report[0] & (1 << 0)) != 0,
+                (report[0] & (1 << 1)) != 0,
+                (report[0] & (1 << 2)) != 0,
+                (report[0] & (1 << 3)) != 0
+            };
+        }
+        
+        public byte[] Raw { private set; get; }
+        public bool[] AuxButtons { private set; get; }
+    }
+}

--- a/TabletDriverLib/Vendors/Wacom/IntuosV3Report.cs
+++ b/TabletDriverLib/Vendors/Wacom/IntuosV3Report.cs
@@ -1,0 +1,31 @@
+using TabletDriverPlugin;
+using TabletDriverPlugin.Tablet;
+
+namespace TabletDriverLib.Vendors.Wacom
+{
+    public class IntuosV3Report : ITabletReport
+    {
+        public IntuosV3Report(byte[] report)
+        {
+            Raw = report;
+
+            ReportID = report[0];
+            var x = (report[2] | (report[3] << 8) | (report[4] << 16));
+            var y = (report[5] | (report[6] << 8) | (report[7] << 16));
+            Position = new Point(x, y);
+            Pressure = (uint)(report[8] | (report[9] << 8));
+
+            PenButtons = new bool[]
+            {
+                (report[1] & (1 << 1)) != 0,
+                (report[1] & (1 << 2)) != 0
+            };
+        }
+        
+        public byte[] Raw { private set; get; }
+        public uint ReportID { private set; get; }
+        public Point Position { private set; get; }
+        public uint Pressure { private set; get; }
+        public bool[] PenButtons { private set; get; }
+    }
+}

--- a/TabletDriverLib/Vendors/Wacom/IntuosV3ReportParser.cs
+++ b/TabletDriverLib/Vendors/Wacom/IntuosV3ReportParser.cs
@@ -1,0 +1,16 @@
+using TabletDriverLib.Tablet;
+using TabletDriverPlugin.Tablet;
+
+namespace TabletDriverLib.Vendors.Wacom
+{
+    public class IntuosV3ReportParser : IReportParser<IDeviceReport>
+    {
+        public virtual IDeviceReport Parse(byte[] data)
+        {
+            if (data[0] == 0x11)
+                return new IntuosV3AuxReport(data);
+            else
+                return new IntuosV3Report(data);
+        }
+    }
+}

--- a/TabletDriverLib/Vendors/Wacom/WacomDriverIntuosV3ReportParser.cs
+++ b/TabletDriverLib/Vendors/Wacom/WacomDriverIntuosV3ReportParser.cs
@@ -1,0 +1,13 @@
+using System.Linq;
+using TabletDriverPlugin.Tablet;
+
+namespace TabletDriverLib.Vendors.Wacom
+{
+    public class WacomDriverIntuosV3ReportParser : IntuosV3ReportParser
+    {
+        public override IDeviceReport Parse(byte[] data)
+        {
+            return base.Parse(data[1..^0]);
+        }
+    }
+}


### PR DESCRIPTION
# Changes
- Add `IntuosV3Report`
  - Add `IntuosV3ReportParser`
  - Add `WacomDriverIntuosV3ReportParser`

## Tablets
Adds support for:
- Wacom CTL-4100
- Wacom CTL-6100
- Wacom PTH-660

# Issues
- Closes #195 
- Closes #199 