### PR TITLE
Get MouseBinding's mouse handler from DriverState

### DIFF
--- a/TabletDriverLib/Binding/MouseBinding.cs
+++ b/TabletDriverLib/Binding/MouseBinding.cs
@@ -16,7 +16,7 @@ namespace TabletDriverLib.Binding
         {
             get 
             {
-                IVirtualPointer mouseHandler = Platform.VirtualPointer;
+                IVirtualPointer mouseHandler = DriverState.OutputMode.Pointer;
                 if (Enum.TryParse<MouseButton>(Property, true, out var mouseButton))
                     return () => mouseHandler.MouseDown(mouseButton);
                 else
@@ -28,7 +28,7 @@ namespace TabletDriverLib.Binding
         {
             get
             {
-                IVirtualPointer mouseHandler = Platform.VirtualPointer;
+                IVirtualPointer mouseHandler = DriverState.OutputMode.Pointer;
                 if (Enum.TryParse<MouseButton>(Property, true, out var mouseButton))
                     return () => mouseHandler.MouseUp(mouseButton);
                 else

--- a/TabletDriverPlugin/Output/AbsoluteOutputMode.cs
+++ b/TabletDriverPlugin/Output/AbsoluteOutputMode.cs
@@ -67,6 +67,7 @@ namespace TabletDriverPlugin.Output
 
         public IVirtualScreen VirtualScreen { set; get; }
         public abstract IVirtualTablet VirtualTablet { get; }
+        public IVirtualPointer Pointer => VirtualTablet;
         public bool AreaClipping { set; get; }
 
         internal void UpdateCache()

--- a/TabletDriverPlugin/Output/IOutputMode.cs
+++ b/TabletDriverPlugin/Output/IOutputMode.cs
@@ -9,5 +9,6 @@ namespace TabletDriverPlugin.Output
         void Read(IDeviceReport report);
         IEnumerable<IFilter> Filters { set; get; }
         TabletProperties TabletProperties { set; get; }
+        IVirtualPointer Pointer { get; }
     }
 }

--- a/TabletDriverPlugin/Output/RelativeOutputMode.cs
+++ b/TabletDriverPlugin/Output/RelativeOutputMode.cs
@@ -29,6 +29,7 @@ namespace TabletDriverPlugin.Output
         }
 
         public abstract IVirtualMouse VirtualMouse { get; }
+        public IVirtualPointer Pointer => VirtualMouse;
 
         public float XSensitivity { set; get; }
         public float YSensitivity { set; get; }


### PR DESCRIPTION
# Changes
- [x] Add `IVirtualPointer Pointer` to IOutputMode
- [x] Implement `Pointer` through IVirtualTablet and IVirtualMouse
- [x] Make MouseBinding use `DriverState.OutputMode.Pointer` for processing MouseUp() and MouseDown()

This fixes the BindingHandler issues when plugins implement their own IOutputMode and IVirtualPointer (including IVirtualTablet and IVirtualMouse)

# Issues
Fixes TouchEmu Plugin