### PR TITLE
Add Huion HS610 configuration

### DIFF
--- a/TabletDriverLib/Configurations/Huion/HS610.json
+++ b/TabletDriverLib/Configurations/Huion/HS610.json
@@ -43,7 +43,6 @@
     "201": "HUION_T194_190307"
   },
   "InitializationStrings": [
-    201,
     200
   ]
 }

--- a/TabletDriverLib/Configurations/Huion/HS610.json
+++ b/TabletDriverLib/Configurations/Huion/HS610.json
@@ -1,0 +1,49 @@
+{
+  "Name": "Huion HS610",
+  "DigitizerIdentifier": {
+    "VendorID": 9580,
+    "ProductID": 109,
+    "InputReportLength": 12,
+    "OutputReportLength": 0,
+    "ReportParser": null,
+    "FeatureInitReport": null,
+    "OutputInitReport": null
+  },
+  "AlternateDigitizerIdentifier": {
+    "VendorID": 0,
+    "ProductID": 0,
+    "InputReportLength": 0,
+    "OutputReportLength": 0,
+    "ReportParser": null,
+    "FeatureInitReport": null,
+    "OutputInitReport": null
+  },
+  "AuxilaryDeviceIdentifier": {
+    "VendorID": 0,
+    "ProductID": 0,
+    "InputReportLength": 0,
+    "OutputReportLength": 0,
+    "ReportParser": null,
+    "FeatureInitReport": null,
+    "OutputInitReport": null
+  },
+  "Width": 254.0,
+  "Height": 160.0,
+  "MaxX": 50800.0,
+  "MaxY": 31750.0,
+  "MaxPressure": 8191,
+  "ActiveReportID": {
+    "Start": 64,
+    "StartInclusive": true,
+    "End": null,
+    "EndInclusive": false
+  },
+  "Attributes": {},
+  "DeviceStrings": {
+    "201": "HUION_T194_190307"
+  },
+  "InitializationStrings": [
+    201,
+    200
+  ]
+}


### PR DESCRIPTION
Not sure why I was getting 0-32767 ranges mentioned in #247 with libusb, in OTD tablet debugger x is 0-50800, y is 0-31750, so those were set.

Everything apart from ranges, dimensions, name and device string was copied from hs611.

Now OTD seems to work, so this closes #247.