### PR TITLE
Comply to OTD rename changes, and other fixes

### DIFF
--- a/OpenTabletDriver/Configurations/Gaomon/S56K.json
+++ b/OpenTabletDriver/Configurations/Gaomon/S56K.json
@@ -5,7 +5,7 @@
     "ProductID": 109,
     "InputReportLength": 8,
     "OutputReportLength": 0,
-    "ReportParser": "TabletDriverLib.Vendors.Gaomon.GaomonReportParser",
+    "ReportParser": "OpenTabletDriver.Vendors.Gaomon.GaomonReportParser",
     "FeatureInitReport": null,
     "OutputInitReport": null
   },

--- a/OpenTabletDriver/Configurations/Gaomon/S56K.json
+++ b/OpenTabletDriver/Configurations/Gaomon/S56K.json
@@ -42,7 +42,7 @@
     "libinputoverride": "1"
   },
   "DeviceStrings": {
-    "201": "HUION_T156"
+    "201": "HUION_T156_\\d{6}$"
   },
   "InitializationStrings": [
     200

--- a/OpenTabletDriver/Configurations/Gaomon/S620.json
+++ b/OpenTabletDriver/Configurations/Gaomon/S620.json
@@ -5,7 +5,7 @@
     "ProductID": 109,
     "InputReportLength": 12,
     "OutputReportLength": 0,
-    "ReportParser": "TabletDriverLib.Vendors.Gaomon.GaomonReportParser",
+    "ReportParser": "OpenTabletDriver.Vendors.Gaomon.GaomonReportParser",
     "FeatureInitReport": null,
     "OutputInitReport": null
   },

--- a/OpenTabletDriver/Configurations/Huion/H430P.json
+++ b/OpenTabletDriver/Configurations/Huion/H430P.json
@@ -2,7 +2,7 @@
   "Name": "Huion H430P",
   "DigitizerIdentifier": {
     "VendorID": 9580,
-    "ProductID": 109,
+    "ProductID": 110,
     "InputReportLength": 12,
     "OutputReportLength": 0,
     "ReportParser": null,
@@ -42,7 +42,7 @@
     "libinputoverride": "1"
   },
   "DeviceStrings": {
-    "201": "HUION_T176"
+    "201": "HUION_T176_\\d{6}$"
   },
   "InitializationStrings": [
     200

--- a/OpenTabletDriver/Configurations/Huion/H640P.json
+++ b/OpenTabletDriver/Configurations/Huion/H640P.json
@@ -42,7 +42,7 @@
     "libinputoverride": "1"
   },
   "DeviceStrings": {
-    "201": "HUION_T173"
+    "201": "HUION_T173_\\d{6}$"
   },
   "InitializationStrings": [
     200

--- a/OpenTabletDriver/Configurations/Huion/HS611.json
+++ b/OpenTabletDriver/Configurations/Huion/HS611.json
@@ -42,10 +42,9 @@
     "libinputoverride": "1"
   },
   "DeviceStrings": {
-    "2": "Huion Tablet_HS611"
+    "201": "HUION_T19c_\\d{6}$"
   },
   "InitializationStrings": [
-    201,
     200
   ]
 }

--- a/OpenTabletDriver/Configurations/Huion/HS64.json
+++ b/OpenTabletDriver/Configurations/Huion/HS64.json
@@ -42,10 +42,9 @@
     "libinputoverride": "1"
   },
   "DeviceStrings": {
-    "2": "Huion Tablet_HS64"
+    "201": "HUION_T193_\\d{6}$"
   },
   "InitializationStrings": [
-    201,
     200
   ]
 }

--- a/OpenTabletDriver/Configurations/Huion/Inspiroy Q11K.json
+++ b/OpenTabletDriver/Configurations/Huion/Inspiroy Q11K.json
@@ -42,7 +42,7 @@
     "libinputoverride": "1"
   },
   "DeviceStrings": {
-    "201": "HUION_TI64"
+    "201": "HUION_TI64_\\d{6}$"
   },
   "InitializationStrings": [
     200

--- a/OpenTabletDriver/Configurations/Huion/New 1060 Plus.json
+++ b/OpenTabletDriver/Configurations/Huion/New 1060 Plus.json
@@ -42,7 +42,7 @@
     "libinputoverride": "1"
   },
   "DeviceStrings": {
-    "201": "HUION_T174"
+    "201": "HUION_T174_\\d{6}$"
   },
   "InitializationStrings": [
     200

--- a/OpenTabletDriver/Configurations/VEIKK/A15 Pro.json
+++ b/OpenTabletDriver/Configurations/VEIKK/A15 Pro.json
@@ -5,7 +5,7 @@
     "ProductID": 6,
     "InputReportLength": 9,
     "OutputReportLength": 0,
-    "ReportParser": "TabletDriverLib.Vendors.SkipByteTabletReportParser",
+    "ReportParser": "OpenTabletDriver.Vendors.SkipByteTabletReportParser",
     "FeatureInitReport": null,
     "OutputInitReport": "CQEE"
   },

--- a/OpenTabletDriver/Configurations/VEIKK/A15.json
+++ b/OpenTabletDriver/Configurations/VEIKK/A15.json
@@ -5,7 +5,7 @@
     "ProductID": 4,
     "InputReportLength": 9,
     "OutputReportLength": 0,
-    "ReportParser": "TabletDriverLib.Vendors.SkipByteTabletReportParser",
+    "ReportParser": "OpenTabletDriver.Vendors.SkipByteTabletReportParser",
     "FeatureInitReport": null,
     "OutputInitReport": "CQEE"
   },

--- a/OpenTabletDriver/Configurations/VEIKK/A30.json
+++ b/OpenTabletDriver/Configurations/VEIKK/A30.json
@@ -5,7 +5,7 @@
     "ProductID": 2,
     "InputReportLength": 9,
     "OutputReportLength": 0,
-    "ReportParser": "TabletDriverLib.Vendors.SkipByteTabletReportParser",
+    "ReportParser": "OpenTabletDriver.Vendors.SkipByteTabletReportParser",
     "FeatureInitReport": null,
     "OutputInitReport": "CQEE"
   },

--- a/OpenTabletDriver/Configurations/VEIKK/A50.json
+++ b/OpenTabletDriver/Configurations/VEIKK/A50.json
@@ -5,7 +5,7 @@
     "ProductID": 3,
     "InputReportLength": 9,
     "OutputReportLength": 0,
-    "ReportParser": "TabletDriverLib.Vendors.SkipByteTabletReportParser",
+    "ReportParser": "OpenTabletDriver.Vendors.SkipByteTabletReportParser",
     "FeatureInitReport": null,
     "OutputInitReport": "CQEE"
   },

--- a/OpenTabletDriver/Configurations/VEIKK/S640.json
+++ b/OpenTabletDriver/Configurations/VEIKK/S640.json
@@ -5,7 +5,7 @@
     "ProductID": 1,
     "InputReportLength": 9,
     "OutputReportLength": 0,
-    "ReportParser": "TabletDriverLib.Vendors.SkipByteTabletReportParser",
+    "ReportParser": "OpenTabletDriver.Vendors.SkipByteTabletReportParser",
     "FeatureInitReport": null,
     "OutputInitReport": "CQEE"
   },

--- a/OpenTabletDriver/Configurations/Wacom/CTE-440.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTE-440.json
@@ -14,7 +14,7 @@
     "ProductID": 21,
     "InputReportLength": 10,
     "OutputReportLength": 0,
-    "ReportParser": "TabletDriverLib.Vendors.SkipByteTabletReportParser",
+    "ReportParser": "OpenTabletDriver.Vendors.SkipByteTabletReportParser",
     "FeatureInitReport": null,
     "OutputInitReport": null
   },

--- a/OpenTabletDriver/Configurations/Wacom/CTH-470.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTH-470.json
@@ -14,7 +14,7 @@
     "ProductID": 222,
     "InputReportLength": 11,
     "OutputReportLength": 0,
-    "ReportParser": "TabletDriverLib.Vendors.SkipByteTabletReportParser",
+    "ReportParser": "OpenTabletDriver.Vendors.SkipByteTabletReportParser",
     "FeatureInitReport": null,
     "OutputInitReport": null
   },

--- a/OpenTabletDriver/Configurations/Wacom/CTH-480.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTH-480.json
@@ -14,7 +14,7 @@
     "ProductID": 770,
     "InputReportLength": 11,
     "OutputReportLength": 0,
-    "ReportParser": "TabletDriverLib.Vendors.SkipByteTabletReportParser",
+    "ReportParser": "OpenTabletDriver.Vendors.SkipByteTabletReportParser",
     "FeatureInitReport": "AgI=",
     "OutputInitReport": null
   },

--- a/OpenTabletDriver/Configurations/Wacom/CTH-490.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTH-490.json
@@ -5,7 +5,7 @@
     "ProductID": 828,
     "InputReportLength": 10,
     "OutputReportLength": 0,
-    "ReportParser": "TabletDriverLib.Vendors.Wacom.IntuosV2ReportParser",
+    "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
     "FeatureInitReport": "AgI=",
     "OutputInitReport": null
   },
@@ -14,7 +14,7 @@
     "ProductID": 828,
     "InputReportLength": 11,
     "OutputReportLength": 0,
-    "ReportParser": "TabletDriverLib.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
+    "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
     "FeatureInitReport": null,
     "OutputInitReport": null
   },

--- a/OpenTabletDriver/Configurations/Wacom/CTH-670.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTH-670.json
@@ -14,7 +14,7 @@
     "ProductID": 223,
     "InputReportLength": 11,
     "OutputReportLength": 0,
-    "ReportParser": "TabletDriverLib.Vendors.SkipByteTabletReportParser",
+    "ReportParser": "OpenTabletDriver.Vendors.SkipByteTabletReportParser",
     "FeatureInitReport": "AgI=",
     "OutputInitReport": null
   },

--- a/OpenTabletDriver/Configurations/Wacom/CTH-680.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTH-680.json
@@ -14,7 +14,7 @@
     "ProductID": 771,
     "InputReportLength": 11,
     "OutputReportLength": 0,
-    "ReportParser": "TabletDriverLib.Vendors.SkipByteTabletReportParser",
+    "ReportParser": "OpenTabletDriver.Vendors.SkipByteTabletReportParser",
     "FeatureInitReport": "AgI=",
     "OutputInitReport": null
   },

--- a/OpenTabletDriver/Configurations/Wacom/CTH-690.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTH-690.json
@@ -5,7 +5,7 @@
     "ProductID": 830,
     "InputReportLength": 10,
     "OutputReportLength": 0,
-    "ReportParser": "TabletDriverLib.Vendors.Wacom.IntuosV2ReportParser",
+    "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
     "FeatureInitReport": "AgI=",
     "OutputInitReport": null
   },
@@ -14,7 +14,7 @@
     "ProductID": 830,
     "InputReportLength": 11,
     "OutputReportLength": 0,
-    "ReportParser": "TabletDriverLib.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
+    "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
     "FeatureInitReport": null,
     "OutputInitReport": null
   },

--- a/OpenTabletDriver/Configurations/Wacom/CTL-4100 Bluetooth.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTL-4100 Bluetooth.json
@@ -5,7 +5,7 @@
     "ProductID": 887,
     "InputReportLength": 361,
     "OutputReportLength": 0,
-    "ReportParser": "TabletDriverLib.Vendors.Wacom.IntuosV3ReportParser",
+    "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV3ReportParser",
     "FeatureInitReport": null,
     "OutputInitReport": null
   },
@@ -14,7 +14,7 @@
     "ProductID": 887,
     "InputReportLength": 193,
     "OutputReportLength": 0,
-    "ReportParser": "TabletDriverLib.Vendors.Wacom.WacomDriverIntuosV3ReportParser",
+    "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV3ReportParser",
     "FeatureInitReport": null,
     "OutputInitReport": null
   },

--- a/OpenTabletDriver/Configurations/Wacom/CTL-4100.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTL-4100.json
@@ -5,7 +5,7 @@
     "ProductID": 884,
     "InputReportLength": 192,
     "OutputReportLength": 0,
-    "ReportParser": "TabletDriverLib.Vendors.Wacom.IntuosV3ReportParser",
+    "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV3ReportParser",
     "FeatureInitReport": null,
     "OutputInitReport": null
   },
@@ -14,7 +14,7 @@
     "ProductID": 884,
     "InputReportLength": 193,
     "OutputReportLength": 0,
-    "ReportParser": "TabletDriverLib.Vendors.Wacom.WacomDriverIntuosV3ReportParser",
+    "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV3ReportParser",
     "FeatureInitReport": null,
     "OutputInitReport": null
   },

--- a/OpenTabletDriver/Configurations/Wacom/CTL-460.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTL-460.json
@@ -14,7 +14,7 @@
     "ProductID": 212,
     "InputReportLength": 11,
     "OutputReportLength": 0,
-    "ReportParser": "TabletDriverLib.Vendors.SkipByteTabletReportParser",
+    "ReportParser": "OpenTabletDriver.Vendors.SkipByteTabletReportParser",
     "FeatureInitReport": null,
     "OutputInitReport": null
   },

--- a/OpenTabletDriver/Configurations/Wacom/CTL-470.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTL-470.json
@@ -14,7 +14,7 @@
     "ProductID": 221,
     "InputReportLength": 11,
     "OutputReportLength": 0,
-    "ReportParser": "TabletDriverLib.Vendors.SkipByteTabletReportParser",
+    "ReportParser": "OpenTabletDriver.Vendors.SkipByteTabletReportParser",
     "FeatureInitReport": null,
     "OutputInitReport": null
   },

--- a/OpenTabletDriver/Configurations/Wacom/CTL-471.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTL-471.json
@@ -14,7 +14,7 @@
     "ProductID": 768,
     "InputReportLength": 11,
     "OutputReportLength": 0,
-    "ReportParser": "TabletDriverLib.Vendors.SkipByteTabletReportParser",
+    "ReportParser": "OpenTabletDriver.Vendors.SkipByteTabletReportParser",
     "FeatureInitReport": null,
     "OutputInitReport": null
   },

--- a/OpenTabletDriver/Configurations/Wacom/CTL-472.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTL-472.json
@@ -14,7 +14,7 @@
     "ProductID": 890,
     "InputReportLength": 11,
     "OutputReportLength": 0,
-    "ReportParser": "TabletDriverLib.Vendors.SkipByteTabletReportParser",
+    "ReportParser": "OpenTabletDriver.Vendors.SkipByteTabletReportParser",
     "FeatureInitReport": null,
     "OutputInitReport": null
   },

--- a/OpenTabletDriver/Configurations/Wacom/CTL-480.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTL-480.json
@@ -14,7 +14,7 @@
     "ProductID": 782,
     "InputReportLength": 11,
     "OutputReportLength": 0,
-    "ReportParser": "TabletDriverLib.Vendors.SkipByteTabletReportParser",
+    "ReportParser": "OpenTabletDriver.Vendors.SkipByteTabletReportParser",
     "FeatureInitReport": null,
     "OutputInitReport": null
   },

--- a/OpenTabletDriver/Configurations/Wacom/CTL-490.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTL-490.json
@@ -5,7 +5,7 @@
     "ProductID": 827,
     "InputReportLength": 10,
     "OutputReportLength": 0,
-    "ReportParser": "TabletDriverLib.Vendors.Wacom.IntuosV2ReportParser",
+    "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
     "FeatureInitReport": null,
     "OutputInitReport": null
   },
@@ -14,7 +14,7 @@
     "ProductID": 827,
     "InputReportLength": 11,
     "OutputReportLength": 0,
-    "ReportParser": "TabletDriverLib.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
+    "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
     "FeatureInitReport": null,
     "OutputInitReport": null
   },

--- a/OpenTabletDriver/Configurations/Wacom/CTL-6100.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTL-6100.json
@@ -5,7 +5,7 @@
     "ProductID": 888,
     "InputReportLength": 192,
     "OutputReportLength": 0,
-    "ReportParser": "TabletDriverLib.Vendors.Wacom.IntuosV3ReportParser",
+    "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV3ReportParser",
     "FeatureInitReport": null,
     "OutputInitReport": null
   },

--- a/OpenTabletDriver/Configurations/Wacom/CTL-671.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTL-671.json
@@ -14,7 +14,7 @@
     "ProductID": 769,
     "InputReportLength": 11,
     "OutputReportLength": 0,
-    "ReportParser": "TabletDriverLib.Vendors.SkipByteTabletReportParser",
+    "ReportParser": "OpenTabletDriver.Vendors.SkipByteTabletReportParser",
     "FeatureInitReport": null,
     "OutputInitReport": null
   },

--- a/OpenTabletDriver/Configurations/Wacom/CTL-672.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTL-672.json
@@ -14,7 +14,7 @@
     "ProductID": 891,
     "InputReportLength": 11,
     "OutputReportLength": 0,
-    "ReportParser": "TabletDriverLib.Vendors.SkipByteTabletReportParser",
+    "ReportParser": "OpenTabletDriver.Vendors.SkipByteTabletReportParser",
     "FeatureInitReport": null,
     "OutputInitReport": null
   },

--- a/OpenTabletDriver/Configurations/Wacom/CTL-680.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTL-680.json
@@ -14,7 +14,7 @@
     "ProductID": 803,
     "InputReportLength": 11,
     "OutputReportLength": 0,
-    "ReportParser": "TabletDriverLib.Vendors.SkipByteTabletReportParser",
+    "ReportParser": "OpenTabletDriver.Vendors.SkipByteTabletReportParser",
     "FeatureInitReport": null,
     "OutputInitReport": null
   },

--- a/OpenTabletDriver/Configurations/Wacom/CTL-690.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTL-690.json
@@ -5,7 +5,7 @@
     "ProductID": 829,
     "InputReportLength": 10,
     "OutputReportLength": 0,
-    "ReportParser": "TabletDriverLib.Vendors.Wacom.IntuosV2ReportParser",
+    "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
     "FeatureInitReport": null,
     "OutputInitReport": null
   },
@@ -14,7 +14,7 @@
     "ProductID": 829,
     "InputReportLength": 11,
     "OutputReportLength": 0,
-    "ReportParser": "TabletDriverLib.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
+    "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
     "FeatureInitReport": null,
     "OutputInitReport": null
   },

--- a/OpenTabletDriver/Configurations/Wacom/PTH-451.json
+++ b/OpenTabletDriver/Configurations/Wacom/PTH-451.json
@@ -5,7 +5,7 @@
     "ProductID": 788,
     "InputReportLength": 10,
     "OutputReportLength": 0,
-    "ReportParser": "TabletDriverLib.Vendors.Wacom.IntuosV2ReportParser",
+    "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
     "FeatureInitReport": null,
     "OutputInitReport": null
   },
@@ -14,7 +14,7 @@
     "ProductID": 788,
     "InputReportLength": 11,
     "OutputReportLength": 0,
-    "ReportParser": "TabletDriverLib.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
+    "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
     "FeatureInitReport": null,
     "OutputInitReport": null
   },

--- a/OpenTabletDriver/Configurations/Wacom/PTH-660.json
+++ b/OpenTabletDriver/Configurations/Wacom/PTH-660.json
@@ -5,7 +5,7 @@
     "ProductID": 855,
     "InputReportLength": 192,
     "OutputReportLength": 0,
-    "ReportParser": "TabletDriverLib.Vendors.Wacom.IntuosV3ReportParser",
+    "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV3ReportParser",
     "FeatureInitReport": null,
     "OutputInitReport": null
   },

--- a/OpenTabletDriver/Configurations/Wacom/PTH-850.json
+++ b/OpenTabletDriver/Configurations/Wacom/PTH-850.json
@@ -5,7 +5,7 @@
     "ProductID": 40,
     "InputReportLength": 10,
     "OutputReportLength": 0,
-    "ReportParser": "TabletDriverLib.Vendors.Wacom.IntuosV2ReportParser",
+    "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
     "FeatureInitReport": null,
     "OutputInitReport": null
   },
@@ -14,7 +14,7 @@
     "ProductID": 40,
     "InputReportLength": 11,
     "OutputReportLength": 0,
-    "ReportParser": "TabletDriverLib.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
+    "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
     "FeatureInitReport": null,
     "OutputInitReport": null
   },

--- a/OpenTabletDriver/Configurations/XP-Pen/G430S_B.json
+++ b/OpenTabletDriver/Configurations/XP-Pen/G430S_B.json
@@ -7,7 +7,7 @@
     "OutputReportLength": 12,
     "ReportParser": null,
     "FeatureInitReport": null,
-    "OutputInitReport": "ArAC"
+    "OutputInitReport": "ArAE"
   },
   "AlternateDigitizerIdentifier": {
     "VendorID": 0,

--- a/OpenTabletDriver/Configurations/XP-Pen/G640s.json
+++ b/OpenTabletDriver/Configurations/XP-Pen/G640s.json
@@ -5,7 +5,7 @@
     "ProductID": 2310,
     "InputReportLength": 10,
     "OutputReportLength": 8,
-    "ReportParser": "TabletDriverLib.Vendors.XP_Pen.XP_PenReportParser",
+    "ReportParser": "OpenTabletDriver.Vendors.XP_Pen.XP_PenReportParser",
     "FeatureInitReport": null,
     "OutputInitReport": "ArAE"
   },
@@ -28,9 +28,9 @@
     "OutputInitReport": null
   },
   "Width": 165.0,
-  "Height": 103.5,
-  "MaxX": 32000.0,
-  "MaxY": 20000.0,
+  "Height": 103.0,
+  "MaxX": 32999.0,
+  "MaxY": 20599.0,
   "MaxPressure": 8191,
   "ActiveReportID": {
     "Start": 79,


### PR DESCRIPTION
# Changes
- [x] Update references to custom parsers
- [x] Update G640S config according to report descriptor
- [x] Update H430P, HS64, and HS611 detection
- [x] Use regex for H640P, Inspiroy Q11K, and New 1060 Plus
- [x] Fix G430S_B's OutputInitReport