### PR TITLE
Offload some tasks and fix async warnings

### DIFF
--- a/OpenTabletDriver.UX/App.cs
+++ b/OpenTabletDriver.UX/App.cs
@@ -13,7 +13,7 @@ namespace OpenTabletDriver.UX
     {
         public static void UnhandledException(object sender, Eto.UnhandledExceptionEventArgs e)
         {
-            var appInfo = Driver.Instance.GetApplicationInfo().Result;
+            var appInfo = Driver.Instance.GetApplicationInfo().ConfigureAwait(false).GetAwaiter().GetResult();
             var exception = (Exception)e.ExceptionObject;
             File.WriteAllLines(Path.Join(appInfo.AppDataDirectory, "ux.log"),
                 new string[]

--- a/OpenTabletDriver.UX/Controls/BindingDisplay.cs
+++ b/OpenTabletDriver.UX/Controls/BindingDisplay.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Eto.Forms;
 using OpenTabletDriver.Binding;
 using OpenTabletDriver.UX.Windows;
@@ -12,19 +13,19 @@ namespace OpenTabletDriver.UX.Controls
             Binding = BindingReference.FromString(binding);
             
             var bindingCommand = new Command();
-            bindingCommand.Executed += async (sender, e) =>
+            bindingCommand.Executed += (sender, e) =>
             {
                 var dialog = new BindingEditorDialog(Binding);
-                Binding = await dialog.ShowModalAsync(this);
+                Binding = dialog.ShowModalAsync(this).ConfigureAwait(false).GetAwaiter().GetResult();
             };
             this.Command = bindingCommand;
 
-            this.MouseDown += async (s, e) => 
+            this.MouseDown += (s, e) =>
             {
                 if (e.Buttons.HasFlag(MouseButtons.Alternate))
                 {
                     var dialog = new AdvancedBindingEditorDialog(Binding);
-                    Binding = await dialog.ShowModalAsync(this);
+                    Binding = dialog.ShowModalAsync(this).ConfigureAwait(false).GetAwaiter().GetResult();
                 }
             };
         }

--- a/OpenTabletDriver.UX/Controls/LogView.cs
+++ b/OpenTabletDriver.UX/Controls/LogView.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using Eto.Forms;
 using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.Logging;
@@ -45,10 +46,10 @@ namespace OpenTabletDriver.UX.Controls
             this.Items.Add(new StackLayoutItem(messageList, HorizontalAlignment.Stretch, true));
             this.Items.Add(new StackLayoutItem(toolbar, HorizontalAlignment.Stretch));
 
-            InitializeAsync();
+            InitializeAsync().ConfigureAwait(false);
         }
 
-        private async void InitializeAsync()
+        private async Task InitializeAsync()
         {
             var currentMessages = from message in await App.Driver.Instance.GetCurrentLog()
                 where message is LogMessage

--- a/OpenTabletDriver.UX/Windows/ConfigurationEditor.cs
+++ b/OpenTabletDriver.UX/Windows/ConfigurationEditor.cs
@@ -60,7 +60,7 @@ namespace OpenTabletDriver.UX.Windows
             deleteConfiguration.Executed += (sender, e) => DeleteConfiguration(SelectedConfiguration);
 
             var generateConfiguration = new Command { ToolBarText = "Generate configuration..." };
-            generateConfiguration.Executed += async (sender, e) => await GenerateConfiguration();
+            generateConfiguration.Executed += (sender, e) => GenerateConfigurationAsync().ConfigureAwait(false);
 
             // Menu
             Menu = new MenuBar
@@ -91,10 +91,10 @@ namespace OpenTabletDriver.UX.Windows
                 }
             };
 
-            InitializeAsync();
+            InitializeAsync().ConfigureAwait(false);
         }
 
-        private async void InitializeAsync()
+        private async Task InitializeAsync()
         {
             var appinfo = await App.Driver.Instance.GetApplicationInfo();
             var configDir = new DirectoryInfo(appinfo.ConfigurationDirectory);
@@ -213,7 +213,7 @@ namespace OpenTabletDriver.UX.Windows
                 _configList.SelectedIndex = Configurations.Count - 1;
         }
 
-        private async Task GenerateConfiguration()
+        private async Task GenerateConfigurationAsync()
         {
             var dialog = new DeviceListDialog();
             if (await dialog.ShowModalAsync() is HidDevice device)

--- a/OpenTabletDriver.UX/Windows/TabletDebugger.cs
+++ b/OpenTabletDriver.UX/Windows/TabletDebugger.cs
@@ -67,17 +67,17 @@ namespace OpenTabletDriver.UX.Windows
 
             this.Content = mainLayout;
 
-            InitializeAsync();
+            InitializeDebugger();
         }
 
-        private void InitializeAsync()
+        private void InitializeDebugger()
         {
             App.Driver.Instance.Report += HandleReport;
-            App.Driver.Instance.SetTabletDebug(true);
+            App.Driver.Instance.SetTabletDebug(true).ConfigureAwait(false);
             this.Closing += (sender, e) =>
             {
                 App.Driver.Instance.Report -= HandleReport;
-                App.Driver.Instance.SetTabletDebug(false);
+                App.Driver.Instance.SetTabletDebug(false).ConfigureAwait(false);
             };
         }
 

--- a/OpenTabletDriver/RPC/RpcClient.cs
+++ b/OpenTabletDriver/RPC/RpcClient.cs
@@ -24,11 +24,14 @@ namespace OpenTabletDriver.RPC
             await stream.ConnectAsync();
             IsConnected = true;
             await Task.Delay(250);
-            Instance = JsonRpc.Attach<T>(stream);
+            RpcInstance = new JsonRpc(stream);
+            Instance = RpcInstance.Attach<T>();
+            RpcInstance.StartListening();
         }
 
         private string pipeName;
         private NamedPipeClientStream stream;
+        public JsonRpc RpcInstance { private set; get; }
         public T Instance { private set; get; }
         public bool IsConnected { private set; get; }
 


### PR DESCRIPTION
# Changes
* Fix async warnings
* Show a MessageBox when daemon gets disconnected
* Offload ApplySettings, SaveSettings and DetectTablet to another thread to avoid blocking UI
* Show Placeholder when manually detecting tablet