### PR TITLE
Remove no-coalesce flag

### DIFF
--- a/OpenTabletDriver/Interop/Input/Mouse/WindowsVirtualMouse.cs
+++ b/OpenTabletDriver/Interop/Input/Mouse/WindowsVirtualMouse.cs
@@ -17,7 +17,7 @@ namespace OpenTabletDriver.Interop.Input.Mouse
             xError = dX % 1;
             yError = dY % 1;
 
-            inputs[0].U.mi.dwFlags = MOUSEEVENTF.MOVE | MOUSEEVENTF.MOVE_NOCOALESCE;
+            inputs[0].U.mi.dwFlags = MOUSEEVENTF.MOVE;
             inputs[0].U.mi.dx = (int)dX;
             inputs[0].U.mi.dy = (int)dY;
             SendInput(1, inputs, INPUT.Size);

--- a/OpenTabletDriver/Interop/Input/Tablet/WindowsVirtualTablet.cs
+++ b/OpenTabletDriver/Interop/Input/Tablet/WindowsVirtualTablet.cs
@@ -12,7 +12,7 @@ namespace OpenTabletDriver.Interop.Input.Tablet
     {
         public void SetPosition(Vector2 pos)
         {
-            inputs[0].U.mi.dwFlags = MOUSEEVENTF.ABSOLUTE | MOUSEEVENTF.MOVE | MOUSEEVENTF.VIRTUALDESK | MOUSEEVENTF.MOVE_NOCOALESCE;
+            inputs[0].U.mi.dwFlags = MOUSEEVENTF.ABSOLUTE | MOUSEEVENTF.MOVE | MOUSEEVENTF.VIRTUALDESK;
             inputs[0].U.mi.dx = (int)(pos.X / Platform.VirtualScreen.Width * 65535);
             inputs[0].U.mi.dy = (int)(pos.Y / Platform.VirtualScreen.Height * 65535);
             SendInput(1, inputs, INPUT.Size);


### PR DESCRIPTION
The `MOVE_NOCOALESCE` flag only added problems by not allowing a target window to "catch-up" when it processes the input for too long. To reproduce, use current master then resize OTD window. Removing the flag fixes that slowness.

Albeit the name, it does not affect RawInput, only the WM_MOUSEMOVE is affected so the change will not change latency for games like Osu!.