### PR TITLE
Fix configuration editor "New Configuration" crash

### DIFF
--- a/OpenTabletDriver.Plugin/Tablet/DetectionRange.cs
+++ b/OpenTabletDriver.Plugin/Tablet/DetectionRange.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+
 namespace OpenTabletDriver.Plugin.Tablet
 {
     public class DetectionRange
@@ -41,7 +43,7 @@ namespace OpenTabletDriver.Plugin.Tablet
         public static DetectionRange Parse(string str)
         {
             var tokens = str.Split("..", 2);
-            if (tokens.Length == 2)
+            if (tokens.Length == 2 && tokens.All(t => t.Length > 0))
             {
                 string left = tokens[0][1..^0];
                 char leftOp = tokens[0][0];

--- a/OpenTabletDriver.UX/Windows/ConfigurationEditor.cs
+++ b/OpenTabletDriver.UX/Windows/ConfigurationEditor.cs
@@ -269,7 +269,7 @@ namespace OpenTabletDriver.UX.Windows
                         (o) => SelectedConfiguration.MaxPressure = uint.TryParse(o, out var val) ? val : 0
                     ),
                     GetControl("Active Report ID",
-                        () => SelectedConfiguration.ActiveReportID.ToString(),
+                        () => SelectedConfiguration.ActiveReportID?.ToString() ?? new DetectionRange().ToString(),
                         (o) => SelectedConfiguration.ActiveReportID = DetectionRange.Parse(o)
                     )
                 ),


### PR DESCRIPTION
# Changes
Adding a new configuration would crash the GUI because of a null DetectionRange