### PR TITLE
Fix area editor rotated limits

### DIFF
--- a/OpenTabletDriver.Plugin/Output/AbsoluteOutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/AbsoluteOutputMode.cs
@@ -102,7 +102,7 @@ namespace OpenTabletDriver.Plugin.Output
 
             // Apply rotation
             res *= Matrix3x2.CreateRotation(
-                (float)(input.Rotation * System.Math.PI / 180));
+                (float)(-input.Rotation * System.Math.PI / 180));
 
             // Scale millimeters to pixels
             res *= Matrix3x2.CreateScale(


### PR DESCRIPTION
# Changes
- Fixed area editor bounds not accommodating for rotation
- Fixed a regression causing area rotation being reversed (ccw instead of cw)