### PR TITLE
Don't rely on .net core's version detection for DPI Awareness

### DIFF
--- a/OpenTabletDriver/Interop/Display/WindowsDisplay.cs
+++ b/OpenTabletDriver/Interop/Display/WindowsDisplay.cs
@@ -15,14 +15,13 @@ namespace OpenTabletDriver.Interop.Display
     {
         public WindowsDisplay()
         {
-            var version = Environment.OSVersion;
-            if (version.Platform == PlatformID.Win32NT
-                && version.Version.Major >= 6
-                && version.Version.Minor >= 2)
+            try
             {
-                Log.Debug("Display", "DPI Awareness enabled");
                 SetProcessDpiAwareness(2);
+                Log.Debug("Display", "DPI Awareness enabled");
             }
+            catch { }
+
             var monitors = GetDisplays().OrderBy(e => e.Left).ToList();
             var primary = monitors.FirstOrDefault(m => m.IsPrimary);
 


### PR DESCRIPTION
.Net Core 3.x don't properly support version detection for Win 8.1+ and this causes problems for Win 8.0 users since it does not support `SetProcessDpiAwareness()`.

Old method mistakenly calls that function when on Win 8.0