### PR TITLE
Update TargetFrameworks of UX.Wpf

### DIFF
--- a/OpenTabletDriver.UX.Wpf/OpenTabletDriver.UX.Wpf.csproj
+++ b/OpenTabletDriver.UX.Wpf/OpenTabletDriver.UX.Wpf.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5-windows</TargetFrameworks>
     <VersionPrefix>0.4.1</VersionPrefix>
     <ApplicationIcon>../OpenTabletDriver.UX/Assets/otd.ico</ApplicationIcon>
   </PropertyGroup>


### PR DESCRIPTION
net5-rc1 required us to append `-windows` when working with WPF apps, and this is expected to not change for the net5 official release