### PR TITLE
Update G640 v2 MaxX and MaxY

### DIFF
--- a/OpenTabletDriver/Configurations/XP-Pen/G640 v2.json
+++ b/OpenTabletDriver/Configurations/XP-Pen/G640 v2.json
@@ -4,8 +4,8 @@
     {
       "Width": 160.0,
       "Height": 100.0,
-      "MaxX": 32000.0,
-      "MaxY": 20000.0,
+      "MaxX": 16000.0,
+      "MaxY": 10000.0,
       "MaxPressure": 8191,
       "ActiveReportID": {
         "Start": 64,

--- a/OpenTabletDriver/Configurations/XP-Pen/G640 v2.json
+++ b/OpenTabletDriver/Configurations/XP-Pen/G640 v2.json
@@ -4,8 +4,8 @@
     {
       "Width": 160.0,
       "Height": 100.0,
-      "MaxX": 16000.0,
-      "MaxY": 10000.0,
+      "MaxX": 15999.0,
+      "MaxY": 9999.0,
       "MaxPressure": 8191,
       "ActiveReportID": {
         "Start": 64,


### PR DESCRIPTION
This is my first time opening a pull request, so please understand if I have done something weird or wrong.

Rev B version of XP-Pen G640 has MaxX value of 16000 and MaxY value of 1000, rather than 32000 and 2000,
Just tested with my Rev B, cursor movement was limited from top left to center with 32000/20000 value.
Worked well with 16000/10000 value.