### PR TITLE
Fallback to Application Directory for Configuration

### DIFF
--- a/OpenTabletDriver.Daemon/Program.cs
+++ b/OpenTabletDriver.Daemon/Program.cs
@@ -2,6 +2,7 @@
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.IO;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using OpenTabletDriver.Plugin;
@@ -52,7 +53,17 @@ namespace OpenTabletDriver.Daemon
                 rootCommand.Handler = CommandHandler.Create<DirectoryInfo, DirectoryInfo>((appdata, config) => 
                 {
                     AppInfo.Current.AppDataDirectory = appdata?.FullName;
-                    AppInfo.Current.ConfigurationDirectory = config?.FullName;
+                    if (config != null && Directory.Exists(config.FullName))
+                    {
+                        AppInfo.Current.ConfigurationDirectory = config.FullName;
+                    }
+                    else if (!Directory.Exists(AppInfo.Current.ConfigurationDirectory))
+                    {
+                        AppInfo.Current.ConfigurationDirectory = Path.Join(
+                            Path.GetDirectoryName(Assembly.GetEntryAssembly().Location),
+                            "Configurations"
+                        );
+                    }
                 });
                 rootCommand.Invoke(args);
 

--- a/OpenTabletDriver.Daemon/Program.cs
+++ b/OpenTabletDriver.Daemon/Program.cs
@@ -53,17 +53,7 @@ namespace OpenTabletDriver.Daemon
                 rootCommand.Handler = CommandHandler.Create<DirectoryInfo, DirectoryInfo>((appdata, config) => 
                 {
                     AppInfo.Current.AppDataDirectory = appdata?.FullName;
-                    if (config != null && Directory.Exists(config.FullName))
-                    {
-                        AppInfo.Current.ConfigurationDirectory = config.FullName;
-                    }
-                    else if (!Directory.Exists(AppInfo.Current.ConfigurationDirectory))
-                    {
-                        AppInfo.Current.ConfigurationDirectory = Path.Join(
-                            Path.GetDirectoryName(Assembly.GetEntryAssembly().Location),
-                            "Configurations"
-                        );
-                    }
+                    AppInfo.Current.ConfigurationDirectory = config?.FullName;
                 });
                 rootCommand.Invoke(args);
 

--- a/OpenTabletDriver.Daemon/Program.cs
+++ b/OpenTabletDriver.Daemon/Program.cs
@@ -2,7 +2,6 @@
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.IO;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using OpenTabletDriver.Plugin;

--- a/OpenTabletDriver/AppInfo.cs
+++ b/OpenTabletDriver/AppInfo.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Reflection;
 using OpenTabletDriver.Native;
 
 namespace OpenTabletDriver
@@ -13,7 +14,25 @@ namespace OpenTabletDriver
         public string ConfigurationDirectory
         {
             set => _configDirectory = value;
-            get => _configDirectory ?? _defaultConfigurationDirectory.Value;
+            // get => _configDirectory ?? _defaultConfigurationDirectory.Value;
+            get
+            {
+                if (Directory.Exists(_configDirectory))
+                {
+                    return _configDirectory;
+                }
+                else if (Directory.Exists(_defaultConfigurationDirectory.Value))
+                {
+                    return _defaultConfigurationDirectory.Value;
+                }
+                else
+                {
+                    return Path.Join(
+                        Path.GetDirectoryName(Assembly.GetEntryAssembly().Location),
+                        "Configurations"
+                    );
+                }
+            }
         }
 
         public string AppDataDirectory


### PR DESCRIPTION
# Changes
- Check first if the user-supplied configuration directory is existing.
- Then check if there is a configuration folder in current working directory.
- And finally fallback to directory of OTD daemon to search for the configuration folder when above checks failed.

# Issues
- Fixes #357

# Reproduction
- ## Windows
  - Use File Explorer search function to launch daemon. (will set cwd to `C:\Windows\System32`)
- ## Linux
  - Launch OTD daemon directly without being in its directory.
- ## All Platforms
  - Supply non-existent configuration directory to daemon.