### PR TITLE
Fixed crash when trying to load plugins

### DIFF
--- a/OpenTabletDriver/PluginManager.cs
+++ b/OpenTabletDriver/PluginManager.cs
@@ -24,7 +24,8 @@ namespace OpenTabletDriver
             if (file.Extension == ".dll")
             {
                 var asm = ImportAssembly(file.FullName);
-                if (asm is null) { return false; }
+                if (asm is null) 
+                    return false;
 
                 foreach (var type in GetLoadableTypes(asm))
                 {

--- a/OpenTabletDriver/PluginManager.cs
+++ b/OpenTabletDriver/PluginManager.cs
@@ -51,7 +51,7 @@ namespace OpenTabletDriver
             {
                 return AssemblyLoadContext.Default.LoadFromAssemblyPath(path);
             }
-            catch (BadImageFormatException e)
+            catch (BadImageFormatException)
             {
                 Log.Write("Plugin", $"Failed to initialize {path}, incompatible plugin", LogLevel.Warning);
                 return null;

--- a/OpenTabletDriver/PluginManager.cs
+++ b/OpenTabletDriver/PluginManager.cs
@@ -21,17 +21,11 @@ namespace OpenTabletDriver
         
         public static bool AddPlugin(FileInfo file)
         {
-            if (file.Extension == ".dll")
+            if (file.Extension == ".dll" && ImportAssembly(file.FullName) is Assembly asm)
             {
-                var asm = ImportAssembly(file.FullName);
-                if (asm is null) 
-                    return false;
-
                 foreach (var type in GetLoadableTypes(asm))
-                {
                     if (TypeIsSupported(type))
                         Types.Add(type.GetTypeInfo());
-                }
                 return true;
             }
             else

--- a/OpenTabletDriver/PluginManager.cs
+++ b/OpenTabletDriver/PluginManager.cs
@@ -24,6 +24,8 @@ namespace OpenTabletDriver
             if (file.Extension == ".dll")
             {
                 var asm = ImportAssembly(file.FullName);
+                if (asm is null) { return false; }
+
                 foreach (var type in GetLoadableTypes(asm))
                 {
                     if (TypeIsSupported(type))
@@ -45,7 +47,15 @@ namespace OpenTabletDriver
 
         private static Assembly ImportAssembly(string path)
         {
-            return AssemblyLoadContext.Default.LoadFromAssemblyPath(path);
+            try
+            {
+                return AssemblyLoadContext.Default.LoadFromAssemblyPath(path);
+            }
+            catch (BadImageFormatException e)
+            {
+                Log.Write("Plugin", $"Failed to initialize {path}, incompatible plugin", LogLevel.Warning);
+                return null;
+            }
         }
 
         private static IEnumerable<Type> GetLoadableTypes(Assembly asm)


### PR DESCRIPTION
Example:
If the dlls from this file are in the plugins folder it would cause a crash
https://github.com/X9VoiD/VoiDPlugins/releases/tag/vmulti