### PR TITLE
Fix OutputReportLength of VEIKK S640

### DIFF
--- a/OpenTabletDriver/Configurations/VEIKK/S640.json
+++ b/OpenTabletDriver/Configurations/VEIKK/S640.json
@@ -16,7 +16,7 @@
       "VendorID": 12267,
       "ProductID": 1,
       "InputReportLength": 9,
-      "OutputReportLength": null,
+      "OutputReportLength": 9,
       "ReportParser": "OpenTabletDriver.Vendors.SkipByteTabletReportParser",
       "FeatureInitReport": null,
       "OutputInitReport": "CQEE",


### PR DESCRIPTION
Not sure how I missed that before on the first PR for VEIKKs