### PR TITLE
Make application data portable

### DIFF
--- a/OpenTabletDriver/AppInfo.cs
+++ b/OpenTabletDriver/AppInfo.cs
@@ -37,7 +37,7 @@ namespace OpenTabletDriver
 
         private readonly Lazy<string> defaultAppDataDirectory = new Lazy<string>(() => 
         {
-            var path = Path.Join(Environment.CurrentDirectory, "userdata");
+            var path = Path.Join(ProgramDirectory, "userdata");
             var fallbackPath = SystemInfo.CurrentPlatform switch
             {
                 RuntimePlatform.Windows => Path.Join(Environment.GetEnvironmentVariable("LOCALAPPDATA"), "OpenTabletDriver"),

--- a/OpenTabletDriver/AppInfo.cs
+++ b/OpenTabletDriver/AppInfo.cs
@@ -14,38 +14,44 @@ namespace OpenTabletDriver
         public string ConfigurationDirectory
         {
             set => this.configDirectory = value;
-            get => this.configDirectory ?? this.defaultConfigurationDirectory.Value;
+            get => this.configDirectory ??= DefaultConfigurationDirectory;
         }
 
         public string AppDataDirectory
         {
             set => this.appDataDirectory = value;
-            get => this.appDataDirectory ?? this.defaultAppDataDirectory.Value;
+            get => this.appDataDirectory ??= DefaultAppDataDirectory;
         }
 
         public string SettingsFile => Path.Join(AppDataDirectory, "settings.json");
         public string PluginDirectory => Path.Join(AppDataDirectory, "Plugins");
 
-        private static string ProgramDirectory => Assembly.GetEntryAssembly().Location;
+        private static string ProgramDirectory => Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
 
-        private readonly Lazy<string> defaultConfigurationDirectory = new Lazy<string>(() => 
+        private static string DefaultConfigurationDirectory
         {
-            var path = Path.Join(Environment.CurrentDirectory, "Configurations");
-            var fallbackPath = Path.Join(ProgramDirectory, "Configurations");
-            return Directory.Exists(path) ? path : Directory.Exists(fallbackPath) ? fallbackPath : null;
-        });
-
-        private readonly Lazy<string> defaultAppDataDirectory = new Lazy<string>(() => 
-        {
-            var path = Path.Join(ProgramDirectory, "userdata");
-            var fallbackPath = SystemInfo.CurrentPlatform switch
+            get
             {
-                RuntimePlatform.Windows => Path.Join(Environment.GetEnvironmentVariable("LOCALAPPDATA"), "OpenTabletDriver"),
-                RuntimePlatform.Linux   => Path.Join(Environment.GetEnvironmentVariable("HOME"), ".config", "OpenTabletDriver"),
-                RuntimePlatform.MacOS   => Path.Join(Environment.GetEnvironmentVariable("HOME"), "Library", "Application Support", "OpenTabletDriver"),
-                _                       => null
-            };
-            return Directory.Exists(path) ? path : Directory.Exists(fallbackPath) ? fallbackPath : null;
-        });
+                var path = Path.Join(ProgramDirectory, "Configurations");
+                var fallbackPath = Path.Join(Environment.CurrentDirectory, "Configurations");
+                return Directory.Exists(path) ? path : fallbackPath;
+            }
+        }
+
+        private static string DefaultAppDataDirectory
+        {
+            get
+            {
+                var path = Path.Join(ProgramDirectory, "userdata");
+                var fallbackPath = SystemInfo.CurrentPlatform switch
+                {
+                    RuntimePlatform.Windows => Path.Join(Environment.GetEnvironmentVariable("LOCALAPPDATA"), "OpenTabletDriver"),
+                    RuntimePlatform.Linux   => Path.Join(Environment.GetEnvironmentVariable("HOME"), ".config", "OpenTabletDriver"),
+                    RuntimePlatform.MacOS   => Path.Join(Environment.GetEnvironmentVariable("HOME"), "Library", "Application Support", "OpenTabletDriver"),
+                    _                       => null
+                };
+                return Directory.Exists(path) ? path : fallbackPath;
+            }
+        }
     }
 }

--- a/OpenTabletDriver/AppInfo.cs
+++ b/OpenTabletDriver/AppInfo.cs
@@ -9,53 +9,43 @@ namespace OpenTabletDriver
     {
         public static readonly AppInfo Current = new AppInfo();
 
-        private string _configDirectory, _appDataDirectory;
+        private string configDirectory, appDataDirectory;
         
         public string ConfigurationDirectory
         {
-            set => _configDirectory = value;
-            // get => _configDirectory ?? _defaultConfigurationDirectory.Value;
-            get
-            {
-                if (Directory.Exists(_configDirectory))
-                {
-                    return _configDirectory;
-                }
-                else if (Directory.Exists(_defaultConfigurationDirectory.Value))
-                {
-                    return _defaultConfigurationDirectory.Value;
-                }
-                else
-                {
-                    return Path.Join(
-                        Path.GetDirectoryName(Assembly.GetEntryAssembly().Location),
-                        "Configurations"
-                    );
-                }
-            }
+            set => this.configDirectory = value;
+            get => this.configDirectory ?? this.defaultConfigurationDirectory.Value;
         }
 
         public string AppDataDirectory
         {
-            set => _appDataDirectory = value;
-            get => _appDataDirectory ?? _defaultAppDataDirectory.Value;
+            set => this.appDataDirectory = value;
+            get => this.appDataDirectory ?? this.defaultAppDataDirectory.Value;
         }
 
         public string SettingsFile => Path.Join(AppDataDirectory, "settings.json");
         public string PluginDirectory => Path.Join(AppDataDirectory, "Plugins");
 
-        private static readonly Lazy<string> _defaultConfigurationDirectory = new Lazy<string>(() => 
-            Path.Join(Environment.CurrentDirectory, "Configurations"));
+        private static string ProgramDirectory => Assembly.GetEntryAssembly().Location;
 
-        private static readonly Lazy<string> _defaultAppDataDirectory = new Lazy<string>(() => 
+        private readonly Lazy<string> defaultConfigurationDirectory = new Lazy<string>(() => 
         {
-            return SystemInfo.CurrentPlatform switch
+            var path = Path.Join(Environment.CurrentDirectory, "Configurations");
+            var fallbackPath = Path.Join(ProgramDirectory, "Configurations");
+            return Directory.Exists(path) ? path : Directory.Exists(fallbackPath) ? fallbackPath : null;
+        });
+
+        private readonly Lazy<string> defaultAppDataDirectory = new Lazy<string>(() => 
+        {
+            var path = SystemInfo.CurrentPlatform switch
             {
                 RuntimePlatform.Windows => Path.Join(Environment.GetEnvironmentVariable("LOCALAPPDATA"), "OpenTabletDriver"),
                 RuntimePlatform.Linux   => Path.Join(Environment.GetEnvironmentVariable("HOME"), ".config", "OpenTabletDriver"),
                 RuntimePlatform.MacOS   => Path.Join(Environment.GetEnvironmentVariable("HOME"), "Library", "Application Support", "OpenTabletDriver"),
                 _                       => null
             };
+            var fallbackPath = Path.Join(Environment.CurrentDirectory, "userdata");
+            return Directory.Exists(path) ? path : Directory.Exists(fallbackPath) ? fallbackPath : null;
         });
     }
 }

--- a/OpenTabletDriver/AppInfo.cs
+++ b/OpenTabletDriver/AppInfo.cs
@@ -37,14 +37,14 @@ namespace OpenTabletDriver
 
         private readonly Lazy<string> defaultAppDataDirectory = new Lazy<string>(() => 
         {
-            var path = SystemInfo.CurrentPlatform switch
+            var path = Path.Join(Environment.CurrentDirectory, "userdata");
+            var fallbackPath = SystemInfo.CurrentPlatform switch
             {
                 RuntimePlatform.Windows => Path.Join(Environment.GetEnvironmentVariable("LOCALAPPDATA"), "OpenTabletDriver"),
                 RuntimePlatform.Linux   => Path.Join(Environment.GetEnvironmentVariable("HOME"), ".config", "OpenTabletDriver"),
                 RuntimePlatform.MacOS   => Path.Join(Environment.GetEnvironmentVariable("HOME"), "Library", "Application Support", "OpenTabletDriver"),
                 _                       => null
             };
-            var fallbackPath = Path.Join(Environment.CurrentDirectory, "userdata");
             return Directory.Exists(path) ? path : Directory.Exists(fallbackPath) ? fallbackPath : null;
         });
     }


### PR DESCRIPTION
# Changes
- Save user settings and load plugins from `appdir/userdata` when available
- Allows for fully portable installations when `userdata` directory exists

# Issues
- Closes #305 