### PR TITLE
Match device to config attributes to improve device selection

### DIFF
--- a/OpenTabletDriver.Desktop/Interop/SystemInterop.cs
+++ b/OpenTabletDriver.Desktop/Interop/SystemInterop.cs
@@ -15,6 +15,11 @@ namespace OpenTabletDriver.Desktop.Interop
 {
     public class SystemInterop : OpenTabletDriver.Interop.SystemInterop
     {
+        protected SystemInterop()
+            : base()
+        {
+        }
+
         public static void Open(string path)
         {
             switch (CurrentPlatform)
@@ -99,7 +104,7 @@ namespace OpenTabletDriver.Desktop.Interop
                 return new WaylandDisplay();
             else if (Environment.GetEnvironmentVariable("DISPLAY") != null)
                 return new XScreen();
-            
+
             Log.Write("Display", "Neither Wayland nor X11 were detected, defaulting to X11.", LogLevel.Warning);
             return new XScreen();
         }

--- a/OpenTabletDriver.Desktop/Interop/SystemInterop.cs
+++ b/OpenTabletDriver.Desktop/Interop/SystemInterop.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 using OpenTabletDriver.Desktop.Interop.Display;
 using OpenTabletDriver.Desktop.Interop.Input.Absolute;
 using OpenTabletDriver.Desktop.Interop.Input.Keyboard;
@@ -14,25 +13,8 @@ using OpenTabletDriver.Plugin.Timers;
 
 namespace OpenTabletDriver.Desktop.Interop
 {
-    public static class SystemInterop
+    public class SystemInterop : OpenTabletDriver.Interop.SystemInterop
     {
-        public static PluginPlatform CurrentPlatform
-        {
-            get
-            {
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                    return PluginPlatform.Windows;
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                    return PluginPlatform.Linux;
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                    return PluginPlatform.MacOS;
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD))
-                    return PluginPlatform.FreeBSD;
-                else
-                    return 0;
-            }
-        }
-
         public static void Open(string path)
         {
             switch (CurrentPlatform)

--- a/OpenTabletDriver/Driver.cs
+++ b/OpenTabletDriver/Driver.cs
@@ -2,9 +2,11 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using HidSharp;
 using OpenTabletDriver.Devices;
+using OpenTabletDriver.Interop;
 using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.Output;
 using OpenTabletDriver.Plugin.Platform.Display;
@@ -91,7 +93,7 @@ namespace OpenTabletDriver
             digitizerIdentifier = default;
             foreach (var identifier in config.DigitizerIdentifiers)
             {
-                var matches = FindMatches(identifier);
+                var matches = FindMatchingDigitizer(identifier, config.Attributes);
 
                 if (matches.Count() > 1)
                     Log.Write("Detect", "More than 1 matching digitizer has been found.", LogLevel.Warning);
@@ -121,7 +123,7 @@ namespace OpenTabletDriver
             auxIdentifier = default;
             foreach (var identifier in config.AuxilaryDeviceIdentifiers)
             {
-                var matches = FindMatches(identifier);
+                var matches = FindMatchingAuxiliary(identifier, config.Attributes);
 
                 if (matches.Count() > 1)
                     Log.Write("Detect", "More than 1 matching auxiliary device has been found.", LogLevel.Warning);
@@ -212,18 +214,51 @@ namespace OpenTabletDriver
             }
         }
 
-        protected IEnumerable<HidDevice> FindMatches(DeviceIdentifier identifier)
+        private IEnumerable<HidDevice> FindMatchingDigitizer(DeviceIdentifier identifier, Dictionary<string, string> attributes)
+        {
+            return from device in FindMatches(identifier)
+                   where DigitizerMatchesAttribute(device, attributes)
+                   select device;
+        }
+
+        private IEnumerable<HidDevice> FindMatchingAuxiliary(DeviceIdentifier identifier, Dictionary<string, string> attributes)
+        {
+            return from device in FindMatches(identifier)
+                   where AuxMatchesAttribute(device, attributes)
+                   select device;
+        }
+
+        private IEnumerable<HidDevice> FindMatches(DeviceIdentifier identifier)
         {
             return from device in DeviceList.Local.GetHidDevices()
                 where identifier.VendorID == device.VendorID
                 where identifier.ProductID == device.ProductID
-                where identifier.InputReportLength == null ? true : identifier.InputReportLength == device.GetMaxInputReportLength()
-                where identifier.OutputReportLength == null ? true : identifier.OutputReportLength == device.GetMaxOutputReportLength()
+                where identifier.InputReportLength == null || identifier.InputReportLength == device.GetMaxInputReportLength()
+                where identifier.OutputReportLength == null || identifier.OutputReportLength == device.GetMaxOutputReportLength()
                 where DeviceMatchesAllStrings(device, identifier)
                 select device;
         }
 
-        protected bool DeviceMatchesAllStrings(HidDevice device, DeviceIdentifier identifier)
+        private bool DigitizerMatchesAttribute(HidDevice device, Dictionary<string, string> attributes)
+        {
+            var devName = device.GetFileSystemName();
+
+            bool interfaceMatches = attributes.ContainsKey("WinInterface") ? Regex.IsMatch(devName, $"&mi_{attributes["WinInterface"]}") : true;
+            bool keyMatches = attributes.ContainsKey("WinUsage") ? Regex.IsMatch(devName, $"&col{attributes["WinUsage"]}") : true;
+
+            return SystemInterop.CurrentPlatform switch
+            {
+                PluginPlatform.Windows => interfaceMatches && keyMatches,
+                _ => true
+            };
+        }
+
+        private bool AuxMatchesAttribute(HidDevice device, Dictionary<string, string> attributes)
+        {
+            return true; // Future proofing
+        }
+
+        private bool DeviceMatchesAllStrings(HidDevice device, DeviceIdentifier identifier)
         {
             if (identifier.DeviceStrings == null || identifier.DeviceStrings.Count == 0)
                 return true;

--- a/OpenTabletDriver/Interop/SystemInterop.cs
+++ b/OpenTabletDriver/Interop/SystemInterop.cs
@@ -1,0 +1,25 @@
+using System.Runtime.InteropServices;
+using OpenTabletDriver.Plugin;
+
+namespace OpenTabletDriver.Interop
+{
+    public class SystemInterop
+    {
+        public static PluginPlatform CurrentPlatform
+        {
+            get
+            {
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                    return PluginPlatform.Windows;
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                    return PluginPlatform.Linux;
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                    return PluginPlatform.MacOS;
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD))
+                    return PluginPlatform.FreeBSD;
+                else
+                    return 0;
+            }
+        }
+    }
+}

--- a/OpenTabletDriver/Interop/SystemInterop.cs
+++ b/OpenTabletDriver/Interop/SystemInterop.cs
@@ -5,6 +5,10 @@ namespace OpenTabletDriver.Interop
 {
     public class SystemInterop
     {
+        protected SystemInterop()
+        {
+        }
+
         public static PluginPlatform CurrentPlatform
         {
             get


### PR DESCRIPTION
## Changes

- Add new Windows-specific `Attributes`.
  - `WinInterface` to match interface using the HID path.
  - `WinUsage` to match HID usage using the HID path.
- Future proof possible additional attributes by matching differently on Aux and Digitizer.

After fiddling around with the initial `WinDeviceMatchesEndpoint()` idea, I think we need to put `Attributes` inside `DigitizerIdentifiers` and `AuxIdentifiers`. This attribute change will be useful for when Windows somehow decides to separate touch, sliders, wheels, stuff, and to clean up the code this PR currently have.

## Issues

Helps #404