### PR TITLE
Update G430S configuration

### DIFF
--- a/OpenTabletDriver/Configurations/XP-Pen/G430S.json
+++ b/OpenTabletDriver/Configurations/XP-Pen/G430S.json
@@ -2,6 +2,30 @@
   "Name": "XP-Pen G430S",
   "DigitizerIdentifiers": [
     {
+      "Width": 114.3,
+      "Height": 73.025,
+      "MaxX": 45720.0,
+      "MaxY": 29210.0,
+      "MaxPressure": 2047,
+      "ActiveReportID": {
+        "Start": 79,
+        "StartInclusive": false,
+        "End": null,
+        "EndInclusive": false
+      },
+      "VendorID": 10429,
+      "ProductID": 117,
+      "InputReportLength": 8,
+      "OutputReportLength": 8,
+      "ReportParser": null,
+      "FeatureInitReport": null,
+      "OutputInitReport": "ArAC",
+      "DeviceStrings": {
+        "4": "V2\\.0"
+      },
+      "InitializationStrings": []
+    },
+    {
       "Width": 101.6,
       "Height": 76.2,
       "MaxX": 20320.0,


### PR DESCRIPTION
Config implies a **10160LPI** device so we use the firmware version to atleast limit where the new config applies.

## Verification

[Discord 1](https://discord.com/channels/615607687467761684/615607687467761690/776617649156915200)
[Discord 2](https://discord.com/channels/615607687467761684/615611007951306863/777334767603154965)