### PR TITLE
Implement rotation in RelativeMode, move deltaing to the end of a pipeline

### DIFF
--- a/OpenTabletDriver.Console/Program.Commands.cs
+++ b/OpenTabletDriver.Console/Program.Commands.cs
@@ -59,12 +59,13 @@ namespace OpenTabletDriver.Console
             });
         }
 
-        static async Task SetSensitivity(float xSens, float ySens)
+        static async Task SetSensitivity(float xSens, float ySens, float rotation = 0)
         {
             await ModifySettings(s => 
             {
                 s.XSensitivity = xSens;
                 s.YSensitivity = ySens;
+                s.RelRotation = rotation;
             });
         }
 
@@ -188,6 +189,7 @@ namespace OpenTabletDriver.Console
             var settings = await GetSettings();
             await Out.WriteLineAsync($"Horizontal Sensitivity: {settings.XSensitivity}px/mm");
             await Out.WriteLineAsync($"Vertical Sensitivity: {settings.YSensitivity}px/mm");
+            await Out.WriteLineAsync($"Relative mode rotation: {settings.RelRotation}degrees");
             await Out.WriteLineAsync($"Reset time: {settings.ResetTime}");
         }
 

--- a/OpenTabletDriver.Console/Program.Commands.cs
+++ b/OpenTabletDriver.Console/Program.Commands.cs
@@ -65,7 +65,7 @@ namespace OpenTabletDriver.Console
             {
                 s.XSensitivity = xSens;
                 s.YSensitivity = ySens;
-                s.RelRotation = rotation;
+                s.RelativeRotation = rotation;
             });
         }
 
@@ -189,7 +189,7 @@ namespace OpenTabletDriver.Console
             var settings = await GetSettings();
             await Out.WriteLineAsync($"Horizontal Sensitivity: {settings.XSensitivity}px/mm");
             await Out.WriteLineAsync($"Vertical Sensitivity: {settings.YSensitivity}px/mm");
-            await Out.WriteLineAsync($"Relative mode rotation: {settings.RelRotation}degrees");
+            await Out.WriteLineAsync($"Relative mode rotation: {settings.RelativeRotation}degrees");
             await Out.WriteLineAsync($"Reset time: {settings.ResetTime}");
         }
 

--- a/OpenTabletDriver.Console/Program.cs
+++ b/OpenTabletDriver.Console/Program.cs
@@ -47,7 +47,7 @@ namespace OpenTabletDriver.Console
         {
             yield return CreateCommand<float, float, float, float>(SetDisplayArea, "Sets the display area");
             yield return CreateCommand<float, float, float, float, float>(SetTabletArea, "Sets the tablet area");
-            yield return CreateCommand<float, float>(SetSensitivity, "Sets the relative sensitivity");
+            yield return CreateCommand<float, float, float>(SetSensitivity, "Sets the relative sensitivity");
             yield return CreateCommand<string, string, float>(SetTipBinding, "Sets the current tip binding");
             yield return CreateCommand<string, string, int>(SetPenBinding, "Sets the current pen button bindings");
             yield return CreateCommand<string, string, int>(SetAuxBinding, "Sets the current express key bindings");

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -227,6 +227,9 @@ namespace OpenTabletDriver.Daemon
             relativeMode.Sensitivity = new Vector2(Settings.XSensitivity, Settings.YSensitivity);
             Log.Write("Settings", $"Relative Mode Sensitivity (X, Y): {relativeMode.Sensitivity}");
 
+            relativeMode.Rotation = Settings.RelRotation;
+            Log.Write("Settings", $"Relative Mode Rotation: {relativeMode.Rotation}");
+
             relativeMode.ResetTime = Settings.ResetTime;
             Log.Write("Settings", $"Reset time: {relativeMode.ResetTime}");
         }

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -227,7 +227,7 @@ namespace OpenTabletDriver.Daemon
             relativeMode.Sensitivity = new Vector2(Settings.XSensitivity, Settings.YSensitivity);
             Log.Write("Settings", $"Relative Mode Sensitivity (X, Y): {relativeMode.Sensitivity}");
 
-            relativeMode.Rotation = Settings.RelRotation;
+            relativeMode.Rotation = Settings.RelativeRotation;
             Log.Write("Settings", $"Relative Mode Rotation: {relativeMode.Rotation}");
 
             relativeMode.ResetTime = Settings.ResetTime;

--- a/OpenTabletDriver.Plugin/Output/AbsoluteOutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/AbsoluteOutputMode.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using OpenTabletDriver.Plugin.Attributes;
@@ -11,59 +12,67 @@ namespace OpenTabletDriver.Plugin.Output
     [PluginIgnore]
     public abstract class AbsoluteOutputMode : BindingHandler, IOutputMode
     {
-        private float _halfDisplayWidth, _halfDisplayHeight, _halfTabletWidth, _halfTabletHeight;
-        private float _minX, _maxX, _minY, _maxY;
-        private Vector2 _min, _max;
-        private Matrix3x2 _transformationMatrix;
+        private List<IFilter> filters, preFilters = new List<IFilter>(), postFilters = new List<IFilter>();
+        private Vector2 min, max;
+        private Matrix3x2 transformationMatrix;
 
-        private List<IFilter> _filters, _preFilters = new List<IFilter>(), _postFilters = new List<IFilter>();
         public IEnumerable<IFilter> Filters
         {
             set
             {
-                _filters = value.ToList();
-                _preFilters.Clear();
-                _postFilters.Clear();
-                foreach (IFilter filter in _filters)
-                    if (filter.FilterStage == FilterStage.PreTranspose)
-                        _preFilters.Add(filter);
-                    else if (filter.FilterStage == FilterStage.PostTranspose)
-                        _postFilters.Add(filter);
+                this.filters = value.ToList();
+                this.preFilters.Clear();
+                this.postFilters.Clear();
+
+                foreach (var filter in this.filters)
+                {
+                    switch (filter.FilterStage)
+                    {
+                        case FilterStage.PreTranspose:
+                            this.preFilters.Add(filter);
+                            break;
+                        case FilterStage.PostTranspose:
+                            this.postFilters.Add(filter);
+                            break;
+                        default:
+                            throw new NotSupportedException();
+                    }
+                }
             }
-            get => _filters;
+            get => this.filters;
         }
 
-        private DigitizerIdentifier _digitizer;
+        private DigitizerIdentifier digitizer;
         public override DigitizerIdentifier Digitizer
         {
             set
             {
-                _digitizer = value;
-                UpdateCache();
+                this.digitizer = value;
+                UpdateTransformMatrix();
             }
-            get => _digitizer;
+            get => this.digitizer;
         }
 
-        private Area _displayArea, _tabletArea;
+        private Area outputArea, inputArea;
 
         public Area Input
         {
             set
             {
-                _tabletArea = value;
-                UpdateCache();
+                this.inputArea = value;
+                UpdateTransformMatrix();
             }
-            get => _tabletArea;
+            get => this.inputArea;
         }
 
         public Area Output
         {
             set
             {
-                _displayArea = value;
-                UpdateCache();
+                this.outputArea = value;
+                UpdateTransformMatrix();
             }
-            get => _displayArea;
+            get => this.outputArea;
         }
 
         public IVirtualScreen VirtualScreen { set; get; }
@@ -72,26 +81,24 @@ namespace OpenTabletDriver.Plugin.Output
         public bool AreaClipping { set; get; }
         public bool AreaLimiting { set; get; }
 
-        internal void UpdateCache()
+        internal void UpdateTransformMatrix()
         {
             if (!(Input is null | Output is null | Digitizer is null))
-                _transformationMatrix = CalculateTransformation(Input, Output, Digitizer);
+                this.transformationMatrix = CalculateTransformation(Input, Output, Digitizer);
 
-            _halfDisplayWidth = Output?.Width / 2 ?? 0;
-            _halfDisplayHeight = Output?.Height / 2 ?? 0;
-            _halfTabletWidth = Input?.Width / 2 ?? 0;
-            _halfTabletHeight = Input?.Height / 2 ?? 0;
+            var halfDisplayWidth = Output?.Width / 2 ?? 0;
+            var halfDisplayHeight = Output?.Height / 2 ?? 0;
 
-            _minX = Output?.Position.X - _halfDisplayWidth ?? 0;
-            _maxX = Output?.Position.X + Output?.Width - _halfDisplayWidth ?? 0;
-            _minY = Output?.Position.Y - _halfDisplayHeight ?? 0;
-            _maxY = Output?.Position.Y + Output?.Height - _halfDisplayHeight ?? 0;
+            var minX = Output?.Position.X - halfDisplayWidth ?? 0;
+            var maxX = Output?.Position.X + Output?.Width - halfDisplayWidth ?? 0;
+            var minY = Output?.Position.Y - halfDisplayHeight ?? 0;
+            var maxY = Output?.Position.Y + Output?.Height - halfDisplayHeight ?? 0;
 
-            _min = new Vector2(_minX, _minY);
-            _max = new Vector2(_maxX, _maxY);
+            this.min = new Vector2(minX, minY);
+            this.max = new Vector2(maxX, maxY);
         }
 
-        internal Matrix3x2 CalculateTransformation(Area input, Area output, DigitizerIdentifier tablet)
+        internal static Matrix3x2 CalculateTransformation(Area input, Area output, DigitizerIdentifier tablet)
         {
             // Convert raw tablet data to millimeters
             var res = Matrix3x2.CreateScale(
@@ -137,22 +144,22 @@ namespace OpenTabletDriver.Plugin.Output
             var pos = new Vector2(report.Position.X, report.Position.Y);
 
             // Pre Filter
-            foreach (IFilter filter in _preFilters)
+            foreach (IFilter filter in this.preFilters)
                 pos = filter.Filter(pos);
 
             // Apply transformation
-            pos = Vector2.Transform(pos, _transformationMatrix);
+            pos = Vector2.Transform(pos, this.transformationMatrix);
 
             // Clipping to display bounds
-            var clippedPoint = Vector2.Clamp(pos, _min, _max);
+            var clippedPoint = Vector2.Clamp(pos, this.min, this.max);
             if (AreaLimiting && clippedPoint != pos)
                 return null;
 
             if (AreaClipping)
-                pos = Vector2.Clamp(pos, _min, _max);
+                pos = clippedPoint;
 
             // Post Filter
-            foreach (IFilter filter in _postFilters)
+            foreach (IFilter filter in this.postFilters)
                 pos = filter.Filter(pos);
 
             return pos;

--- a/OpenTabletDriver.Plugin/Output/RelativeOutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/RelativeOutputMode.cs
@@ -56,6 +56,7 @@ namespace OpenTabletDriver.Plugin.Output
 
         private void UpdateTransformMatrix()
         {
+            _lastReceived = default;  // Prevents cursor from jumping on sensitivity change
             _transformationMatrix = Matrix3x2.CreateRotation(
                 (float)(_rotation * System.Math.PI / 180));
 
@@ -106,7 +107,7 @@ namespace OpenTabletDriver.Plugin.Output
             var delta = pos - _lastPos;
             _lastPos = pos;
 
-            return (difference > ResetTime && _lastReceived != default) ? null : delta;
+            return (difference > ResetTime) ? null : delta;
         }
     }
 }

--- a/OpenTabletDriver.Plugin/Output/RelativeOutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/RelativeOutputMode.cs
@@ -58,7 +58,7 @@ namespace OpenTabletDriver.Plugin.Output
         {
             _lastReceived = default;  // Prevents cursor from jumping on sensitivity change
             _transformationMatrix = Matrix3x2.CreateRotation(
-                (float)(_rotation * System.Math.PI / 180));
+                (float)(-_rotation * System.Math.PI / 180));
 
             _transformationMatrix *= Matrix3x2.CreateScale(
                 _sensitivity.X * ((Digitizer?.Width / Digitizer?.MaxX) ?? 0.01f),

--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -301,7 +301,12 @@ namespace OpenTabletDriver.UX
                 () => App.Settings.YSensitivity.ToString(),
                 "px/mm"
             );
-            
+            var rotationBox = ConstructSensitivityEditor(
+                "Rotation",
+                (s) => App.Settings.RelRotation = float.TryParse(s, out var val) ? val : 0f,
+                () => App.Settings.RelRotation.ToString(),
+                "degrees"
+            );
             var resetTimeBox = ConstructSensitivityEditor(
                 "Reset Time",
                 (s) => App.Settings.ResetTime = TimeSpan.TryParse(s, out var val) ? val : TimeSpan.FromMilliseconds(100),
@@ -317,6 +322,7 @@ namespace OpenTabletDriver.UX
                 {
                     new StackLayoutItem(xSensBox, true),
                     new StackLayoutItem(ySensBox, true),
+                    new StackLayoutItem(rotationBox, true),
                     new StackLayoutItem(resetTimeBox, true)
                 }
             };

--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -303,8 +303,8 @@ namespace OpenTabletDriver.UX
             );
             var rotationBox = ConstructSensitivityEditor(
                 "Rotation",
-                (s) => App.Settings.RelRotation = float.TryParse(s, out var val) ? val : 0f,
-                () => App.Settings.RelRotation.ToString(),
+                (s) => App.Settings.RelativeRotation = float.TryParse(s, out var val) ? val : 0f,
+                () => App.Settings.RelativeRotation.ToString(),
                 "degrees"
             );
             var resetTimeBox = ConstructSensitivityEditor(

--- a/OpenTabletDriver/Settings.cs
+++ b/OpenTabletDriver/Settings.cs
@@ -192,8 +192,8 @@ namespace OpenTabletDriver
             get => _yS;
         }
 
-        [JsonProperty("RelRotation")]
-        public float RelRotation
+        [JsonProperty("RelativeRotation")]
+        public float RelativeRotation
         {
             set => this.RaiseAndSetIfChanged(ref _relRot, value);
             get => _relRot;
@@ -318,7 +318,7 @@ namespace OpenTabletDriver
             PluginSettings = new Dictionary<string, string>(),
             XSensitivity = 10,
             YSensitivity = 10,
-            RelRotation = 0,
+            RelativeRotation = 0,
             ResetTime = TimeSpan.FromMilliseconds(100)
         };
 

--- a/OpenTabletDriver/Settings.cs
+++ b/OpenTabletDriver/Settings.cs
@@ -18,7 +18,7 @@ namespace OpenTabletDriver
         internal const int PenButtonCount = 2;
         internal const int AuxButtonCount = 6;
 
-        private float _dW, _dH, _dX, _dY, _tW, _tH, _tX, _tY, _r, _xS, _yS, _tP;
+        private float _dW, _dH, _dX, _dY, _tW, _tH, _tX, _tY, _r, _xS, _yS, _relRot, _tP;
         private TimeSpan _rT;
         private bool _lockar, _sizeChanging, _autoHook, _clipping, _areaLimiting;
         private string _outputMode, _tipButton;
@@ -192,6 +192,13 @@ namespace OpenTabletDriver
             get => _yS;
         }
 
+        [JsonProperty("RelRotation")]
+        public float RelRotation
+        {
+            set => this.RaiseAndSetIfChanged(ref _relRot, value);
+            get => _relRot;
+        }
+
         [JsonProperty("RelativeResetDelay")]
         public TimeSpan ResetTime
         {
@@ -311,6 +318,7 @@ namespace OpenTabletDriver
             PluginSettings = new Dictionary<string, string>(),
             XSensitivity = 10,
             YSensitivity = 10,
+            RelRotation = 0,
             ResetTime = TimeSpan.FromMilliseconds(100)
         };
 


### PR DESCRIPTION
Rotation is done via a transform matrix, along with a sensitivity scaling.
Moving delta creation to the end allows filters to work with position instead of velocity, which they were not designed to handle.