### PR TITLE
Fix CTL-6100 configuration 

### DIFF
--- a/OpenTabletDriver/Configurations/Wacom/CTL-6100.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTL-6100.json
@@ -8,9 +8,9 @@
       "MaxY": 13500.0,
       "MaxPressure": 4095,
       "ActiveReportID": {
-        "Start": 16,
-        "StartInclusive": true,
-        "End": null,
+        "Start": null,
+        "StartInclusive": false,
+        "End": 19,
         "EndInclusive": false
       },
       "VendorID": 1386,
@@ -22,42 +22,8 @@
       "OutputInitReport": null,
       "DeviceStrings": {},
       "InitializationStrings": []
-    },
-    {
-      "Width": 216.0,
-      "Height": 135.0,
-      "MaxX": 21600.0,
-      "MaxY": 13500.0,
-      "MaxPressure": 4095,
-      "ActiveReportID": {
-        "Start": 16,
-        "StartInclusive": true,
-        "End": null,
-        "EndInclusive": false
-      },
-      "VendorID": 1386,
-      "ProductID": 888,
-      "InputReportLength": null,
-      "OutputReportLength": null,
-      "ReportParser": null,
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": []
     }
   ],
-  "AuxilaryDeviceIdentifiers": [
-    {
-      "VendorID": 1386,
-      "ProductID": 888,
-      "InputReportLength": null,
-      "OutputReportLength": null,
-      "ReportParser": null,
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": []
-    }
-  ],
+  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {}
 }


### PR DESCRIPTION
# Changes
- Configuration was broken, forcing the cursor to lock in the top center of the selected output area when inactive

# Verification
- PM with `Sam~#0101` on Discord

I want a secondary verification if at all possible.