### PR TITLE
Interpolator patch

### DIFF
--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -315,7 +315,6 @@ namespace OpenTabletDriver.Daemon
                     }
 
                     Driver.Interpolators.Add(interpolator);
-                    interpolator.Enabled = true;
 
                     Log.Write("Settings", $"Interpolator: {interpolator}");
                 }

--- a/OpenTabletDriver.Plugin/Tablet/Interpolator/Interpolator.cs
+++ b/OpenTabletDriver.Plugin/Tablet/Interpolator/Interpolator.cs
@@ -104,7 +104,8 @@ namespace OpenTabletDriver.Plugin.Tablet.Interpolator
         {
             if (!isDisposed)
             {
-                Enabled = false;
+                if (Enabled)
+                    Enabled = false;
                 this.scheduler.Elapsed -= InterpolateHook;
                 Info.Driver.ReportRecieved -= HandleReport;
                 this.scheduler.Dispose();

--- a/OpenTabletDriver.Plugin/Tablet/Interpolator/Interpolator.cs
+++ b/OpenTabletDriver.Plugin/Tablet/Interpolator/Interpolator.cs
@@ -100,13 +100,24 @@ namespace OpenTabletDriver.Plugin.Tablet.Interpolator
             }
         }
 
-        public virtual void Dispose()
+        public void Dispose()
         {
-            Enabled = false;
-            this.scheduler.Elapsed -= InterpolateHook;
-            Info.Driver.ReportRecieved -= HandleReport;
-            this.scheduler.Dispose();
-            GC.SuppressFinalize(this);
+            if (!isDisposed)
+            {
+                Enabled = false;
+                this.scheduler.Elapsed -= InterpolateHook;
+                Info.Driver.ReportRecieved -= HandleReport;
+                this.scheduler.Dispose();
+                GC.SuppressFinalize(this);
+                isDisposed = true;
+            }
         }
+
+        ~Interpolator()
+        {
+            Dispose();
+        }
+
+        private bool isDisposed;
     }
 }

--- a/OpenTabletDriver/Interop/Timer/FallbackTimer.cs
+++ b/OpenTabletDriver/Interop/Timer/FallbackTimer.cs
@@ -57,7 +57,7 @@ namespace OpenTabletDriver.Interop.Timer
             this.runTimer = false;
         }
 
-        void ThreadMain()
+        private void ThreadMain()
         {
             float nextNotification = 0;
             float elapsedMilliseconds;

--- a/OpenTabletDriver/Interop/Timer/FallbackTimer.cs
+++ b/OpenTabletDriver/Interop/Timer/FallbackTimer.cs
@@ -5,13 +5,13 @@ using OpenTabletDriver.Plugin.Timers;
 
 namespace OpenTabletDriver.Interop.Timer
 {
-    internal class FallbackTimer : ITimer
+    internal class FallbackTimer : ITimer, IDisposable
     {
         public event Action Elapsed;
 
-        private Thread threadTimer = null;
+        private Thread threadTimer;
         private float ignoreEventIfLateBy = float.MaxValue;
-        private float timerInterval = 0;
+        private float timerInterval;
         private bool runTimer = true;
 
         public FallbackTimer()
@@ -45,7 +45,7 @@ namespace OpenTabletDriver.Interop.Timer
 
             this.runTimer = true;
 
-            this.threadTimer = new Thread(NotificationTimer)
+            this.threadTimer = new Thread(ThreadMain)
             {
                 Priority = ThreadPriority.Highest
             };
@@ -57,7 +57,7 @@ namespace OpenTabletDriver.Interop.Timer
             this.runTimer = false;
         }
 
-        void NotificationTimer()
+        void ThreadMain()
         {
             float nextNotification = 0;
             float elapsedMilliseconds;

--- a/OpenTabletDriver/Interop/Timer/FallbackTimer.cs
+++ b/OpenTabletDriver/Interop/Timer/FallbackTimer.cs
@@ -90,6 +90,8 @@ namespace OpenTabletDriver.Interop.Timer
 
         public void Dispose()
         {
+            if (Enabled)
+                Stop();
         }
     }
 }

--- a/OpenTabletDriver/Interop/Timer/LinuxTimer.cs
+++ b/OpenTabletDriver/Interop/Timer/LinuxTimer.cs
@@ -10,7 +10,7 @@ namespace OpenTabletDriver.Interop.Timer
 {
     using static Timers;
 
-    internal class LinuxTimer : ITimer
+    internal class LinuxTimer : ITimer, IDisposable
     {
         private IntPtr timerID;
         private readonly TimerCallback callbackDelegate;
@@ -53,7 +53,7 @@ namespace OpenTabletDriver.Interop.Timer
                     interval = new TimeSpec
                     {
                         sec = 0,
-                        nsec = (long)(interval)
+                        nsec = (long)interval
                     },
                     value = new TimeSpec
                     {
@@ -64,7 +64,7 @@ namespace OpenTabletDriver.Interop.Timer
 
                 var oldTimeSpec = new TimerSpec();
 
-                var setErr = TimerSetTime(timerID, 0, ref timeSpec, ref oldTimeSpec);
+                var setErr = TimerSetTime(timerID, TimerFlag.Default, ref timeSpec, ref oldTimeSpec);
                 if (setErr != ERRNO.NONE)
                 {
                     Log.Write("LinuxTimer", $"Failed activating the timer: ${(ERRNO)Marshal.GetLastWin32Error()}", LogLevel.Error);
@@ -115,7 +115,7 @@ namespace OpenTabletDriver.Interop.Timer
 
         public bool Enabled { private set; get; }
 
-        public float Interval { set; get; }
+        public float Interval { set; get; } = 1;
 
         public event Action Elapsed;
     }

--- a/OpenTabletDriver/Interop/Timer/LinuxTimer.cs
+++ b/OpenTabletDriver/Interop/Timer/LinuxTimer.cs
@@ -110,6 +110,8 @@ namespace OpenTabletDriver.Interop.Timer
 
         public void Dispose()
         {
+            if (Enabled)
+                Stop();
             callbackHandle.Free();
             GC.SuppressFinalize(this);
         }

--- a/OpenTabletDriver/Interop/Timer/LinuxTimer.cs
+++ b/OpenTabletDriver/Interop/Timer/LinuxTimer.cs
@@ -111,6 +111,7 @@ namespace OpenTabletDriver.Interop.Timer
         public void Dispose()
         {
             callbackHandle.Free();
+            GC.SuppressFinalize(this);
         }
 
         public bool Enabled { private set; get; }

--- a/OpenTabletDriver/Interop/Timer/WindowsTimer.cs
+++ b/OpenTabletDriver/Interop/Timer/WindowsTimer.cs
@@ -51,6 +51,7 @@ namespace OpenTabletDriver.Interop.Timer
         public void Dispose()
         {
             callbackHandle.Free();
+            GC.SuppressFinalize(this);
         }
 
         public bool Enabled { private set; get; }

--- a/OpenTabletDriver/Interop/Timer/WindowsTimer.cs
+++ b/OpenTabletDriver/Interop/Timer/WindowsTimer.cs
@@ -50,6 +50,8 @@ namespace OpenTabletDriver.Interop.Timer
 
         public void Dispose()
         {
+            if (Enabled)
+                Stop();
             callbackHandle.Free();
             GC.SuppressFinalize(this);
         }


### PR DESCRIPTION
## Changes

- Do not set `interpolator.Enabled` from inside DriverDaemon.cs. This causes an unused running timer to be leaked.
- Remove delay of starting timers.
- Explicitly implement `IDisposable`.
- A bit of code cleanup and memory leak fix.