### PR TITLE
Add configurations to OpenTabletDriver project as embedded resource

### DIFF
--- a/OpenTabletDriver/OpenTabletDriver.csproj
+++ b/OpenTabletDriver/OpenTabletDriver.csproj
@@ -25,4 +25,10 @@
     <ProjectReference Include="..\OpenTabletDriver.Plugin\OpenTabletDriver.Plugin.csproj" />
   </ItemGroup>
 
+  <ItemGroup Label="Configurations">
+    <EmbeddedResource Include=".\Configurations\*\*.json">
+      <IncludeInPackage>true</IncludeInPackage>
+    </EmbeddedResource>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
# Changes
- NuGet package will build with configurations as embedded resources
- Can be accessed with code similar to the following:
```cs
private IEnumerable<TabletConfiguration> GetConfigurations()
{
    // Retreive all embedded configurations
    var asm = typeof(Driver).Assembly;
    return from path in asm.GetManifestResourceNames()
           where path.Contains(".json")
           let stream = asm.GetManifestResourceStream(path)
           select Deserialize(stream);
}

private TabletConfiguration Deserialize(Stream stream)
{
    using (var tr = new StreamReader(stream))
    using (var jr = new JsonTextReader(tr))
        return ConfigurationSerializer.Deserialize<TabletConfiguration>(jr);
}

private JsonSerializer ConfigurationSerializer { get; } = new JsonSerializer();
```