### PR TITLE
Add and merge Star 03 and Star 03v2

### DIFF
--- a/OpenTabletDriver/Configurations/XP-Pen/Star 03.json
+++ b/OpenTabletDriver/Configurations/XP-Pen/Star 03.json
@@ -1,5 +1,5 @@
 {
-  "Name": "XP-Pen Star 03v2",
+  "Name": "XP-Pen Star 03",
   "DigitizerIdentifiers": [
     {
       "Width": 254.0,
@@ -17,6 +17,28 @@
       "ProductID": 2311,
       "InputReportLength": 10,
       "OutputReportLength": 8,
+      "ReportParser": null,
+      "FeatureInitReport": null,
+      "OutputInitReport": "ArAE",
+      "DeviceStrings": {},
+      "InitializationStrings": []
+    },
+    {
+      "Width": 254.0,
+      "Height": 152.4,
+      "MaxX": 50800.0,
+      "MaxY": 30480.0,
+      "MaxPressure": 8191,
+      "ActiveReportID": {
+        "Start": 80,
+        "StartInclusive": true,
+        "End": 96,
+        "EndInclusive": false
+      },
+      "VendorID": 10429,
+      "ProductID": 2311,
+      "InputReportLength": 10,
+      "OutputReportLength": 10,
       "ReportParser": null,
       "FeatureInitReport": null,
       "OutputInitReport": "ArAE",


### PR DESCRIPTION
XP-Pen's Star 03 and Star 03v2 have the same identifier except output report length.

## Verification

[Discord](https://discord.com/channels/615607687467761684/615611007951306863/784018777767018506)