### PR TITLE
Use MaskedTextBox<T> for plugin settings

### DIFF
--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -240,7 +240,7 @@ namespace OpenTabletDriver.Daemon
         {
             BindingHandler.TipBinding = Settings.TipButton?.Construct<IBinding>();
             BindingHandler.TipActivationPressure = Settings.TipActivationPressure;
-            Log.Write("Settings", $"Tip Binding: '{(BindingHandler.TipBinding is IBinding binding ? binding.ToString() : "None")}'@{BindingHandler.TipActivationPressure}%");
+            Log.Write("Settings", $"Tip Binding: [{BindingHandler.TipBinding}]@{BindingHandler.TipActivationPressure}%");
     
             if (Settings.PenButtons != null)
             {


### PR DESCRIPTION
# Changes
- Use `NumericMaskedTextBox<T>` and `MaskedTextBox<T>` for plugin settings
- Enforces only valid values