### PR TITLE
Fix opening folders with spaces on Windows, again

### DIFF
--- a/OpenTabletDriver.Desktop/Interop/SystemInterop.cs
+++ b/OpenTabletDriver.Desktop/Interop/SystemInterop.cs
@@ -59,11 +59,7 @@ namespace OpenTabletDriver.Desktop.Interop
             switch (CurrentPlatform)
             {
                 case PluginPlatform.Windows:
-                    var startInfo = new ProcessStartInfo("explorer", $"\"{path.Replace("&", "^&")}\"")
-                    {
-                        CreateNoWindow = true
-                    };
-                    Process.Start(startInfo);
+                    Process.Start("explorer", $"\"{path.Replace("&", "^&")}\"");
                     break;
                 default:
                     Open(path);

--- a/OpenTabletDriver.Desktop/Interop/SystemInterop.cs
+++ b/OpenTabletDriver.Desktop/Interop/SystemInterop.cs
@@ -38,7 +38,7 @@ namespace OpenTabletDriver.Desktop.Interop
             switch (CurrentPlatform)
             {
                 case PluginPlatform.Windows:
-                    var startInfo = new ProcessStartInfo("cmd", $"/c start \"{path.Replace("&", "^&")}\"")
+                    var startInfo = new ProcessStartInfo("cmd", $"/c start {path.Replace("&", "^&")}")
                     {
                         CreateNoWindow = true
                     };
@@ -50,6 +50,23 @@ namespace OpenTabletDriver.Desktop.Interop
                 case PluginPlatform.MacOS:
                 case PluginPlatform.FreeBSD:
                     Process.Start("open", $"\"{path}\"");
+                    break;
+            }
+        }
+
+        public static void OpenFolder(string path)
+        {
+            switch (CurrentPlatform)
+            {
+                case PluginPlatform.Windows:
+                    var startInfo = new ProcessStartInfo("explorer", $"\"{path.Replace("&", "^&")}\"")
+                    {
+                        CreateNoWindow = true
+                    };
+                    Process.Start(startInfo);
+                    break;
+                default:
+                    Open(path);
                     break;
             }
         }

--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -372,7 +372,7 @@ namespace OpenTabletDriver.UX
             configurationEditor.Executed += (sender, e) => ShowConfigurationEditor();
 
             var pluginsDirectory = new Command { MenuText = "Open plugins directory..." };
-            pluginsDirectory.Executed += (sender, e) => SystemInterop.Open(AppInfo.Current.PluginDirectory);
+            pluginsDirectory.Executed += (sender, e) => SystemInterop.OpenFolder(AppInfo.Current.PluginDirectory);
 
             var pluginsRepository = new Command { MenuText = "Open plugins repository..." };
             pluginsRepository.Executed += (sender, e) => SystemInterop.Open(App.PluginRepositoryUrl);


### PR DESCRIPTION
Reuse `SystemInterop.Open()` where possible

## Issues

Fixes #508 