### PR TITLE
Use cached sans font and update layout when setting Control

### DIFF
--- a/OpenTabletDriver.UX/Controls/Generic/Group.cs
+++ b/OpenTabletDriver.UX/Controls/Generic/Group.cs
@@ -30,7 +30,7 @@ namespace OpenTabletDriver.UX.Controls.Generic
         
         private Label titleLabel = new Label
         {
-            Font = Fonts.Sans(SystemInterop.CurrentPlatform == PluginPlatform.MacOS ? 12 : 9, FontStyle.Bold)
+            Font = Fonts.Cached("Sans", SystemInterop.CurrentPlatform == PluginPlatform.MacOS ? 12 : 9)
         };
 
         public string Text
@@ -39,7 +39,15 @@ namespace OpenTabletDriver.UX.Controls.Generic
             get => titleLabel.Text;
         }
 
-        public new Control Content { set; get; }
+        private Control content;
+        public new Control Content {
+            set
+            {
+                this.content = value;
+                UpdateControlLayout();
+            }
+            get => content;
+        }
 
         public Orientation Orientation { set; get; } = DEFAULT_ORIENTATION;
         public bool ExpandContent { set; get; } = true;

--- a/OpenTabletDriver.UX/Controls/Generic/Group.cs
+++ b/OpenTabletDriver.UX/Controls/Generic/Group.cs
@@ -30,7 +30,7 @@ namespace OpenTabletDriver.UX.Controls.Generic
         
         private Label titleLabel = new Label
         {
-            Font = Fonts.Cached("Sans", SystemInterop.CurrentPlatform == PluginPlatform.MacOS ? 12 : 9, FontStyle.Bold)
+            Font = Fonts.Cached("Sans", 9, FontStyle.Bold)
         };
 
         public string Text

--- a/OpenTabletDriver.UX/Controls/Generic/Group.cs
+++ b/OpenTabletDriver.UX/Controls/Generic/Group.cs
@@ -30,7 +30,7 @@ namespace OpenTabletDriver.UX.Controls.Generic
         
         private Label titleLabel = new Label
         {
-            Font = Fonts.Cached("Sans", SystemInterop.CurrentPlatform == PluginPlatform.MacOS ? 12 : 9)
+            Font = Fonts.Cached("Sans", SystemInterop.CurrentPlatform == PluginPlatform.MacOS ? 12 : 9, FontStyle.Bold)
         };
 
         public string Text


### PR DESCRIPTION
- Fixes issues with advanced binding editor when opening it from a cleared binding (combobox never shows up for binding property)