### PR TITLE
Fix multiple null crashes

### DIFF
--- a/OpenTabletDriver.Desktop/Reflection/PluginSetting.cs
+++ b/OpenTabletDriver.Desktop/Reflection/PluginSetting.cs
@@ -37,26 +37,12 @@ namespace OpenTabletDriver.Desktop.Reflection
 
         public void SetValue(object value)
         {
-            Value = value switch
-            {
-                string val => val,
-                bool val => val,
-                int val => val,
-                uint val => val,
-                float val => val,
-                double val => val,
-                DateTime val => val,
-                TimeSpan val => val,
-                Guid val => val,
-                Uri val => val,
-                Enum val => JObject.FromObject(val),
-                _ => value != null ? JObject.FromObject(value) : null
-            };
+            Value = JToken.FromObject(value);
         }
 
         public T GetValue<T>()
         {
-            return Value?.Type != JTokenType.Null ? Value.ToObject<T>() : default(T);
+            return Value == null ? default(T) : Value.Type != JTokenType.Null ? Value.ToObject<T>() : default(T);
         }
 
         public object GetValue(Type asType)

--- a/OpenTabletDriver.Desktop/Reflection/PluginSetting.cs
+++ b/OpenTabletDriver.Desktop/Reflection/PluginSetting.cs
@@ -47,7 +47,7 @@ namespace OpenTabletDriver.Desktop.Reflection
 
         public object GetValue(Type asType)
         {
-            return Value?.ToObject(asType);
+            return Value == null ? default : Value.Type != JTokenType.Null ? Value.ToObject(asType) : default;
         }
     }
 }

--- a/OpenTabletDriver.Desktop/Reflection/PluginSetting.cs
+++ b/OpenTabletDriver.Desktop/Reflection/PluginSetting.cs
@@ -56,7 +56,7 @@ namespace OpenTabletDriver.Desktop.Reflection
 
         public T GetValue<T>()
         {
-            return Value != null ? Value.ToObject<T>() : default(T);
+            return Value?.Type != JTokenType.Null ? Value.ToObject<T>() : default(T);
         }
 
         public object GetValue(Type asType)

--- a/OpenTabletDriver.UX/Controls/Generic/Group.cs
+++ b/OpenTabletDriver.UX/Controls/Generic/Group.cs
@@ -28,16 +28,7 @@ namespace OpenTabletDriver.UX.Controls.Generic
         protected virtual Color HorizontalBackgroundColor => SystemColors.ControlBackground;
         protected virtual Color VerticalBackgroundColor => SystemColors.WindowBackground;
         
-        private Label titleLabel = new Label
-        {
-            Font = Fonts.Cached("Sans", 9, FontStyle.Bold)
-        };
-
-        public string Text
-        {
-            set => titleLabel.Text = value;
-            get => titleLabel.Text;
-        }
+        public string Text { set; get; }
 
         private Control content;
         public new Control Content {
@@ -62,7 +53,7 @@ namespace OpenTabletDriver.UX.Controls.Generic
                 {
                     base.Content = new GroupBox
                     {
-                        Text = titleLabel.Text,
+                        Text = this.Text,
                         Padding = new Padding(0, 2, 0, 0),
                         Content = this.Content
                     };
@@ -82,7 +73,15 @@ namespace OpenTabletDriver.UX.Controls.Generic
                             Padding = ContentPadding,
                             Items =
                             {
-                                new StackLayoutItem(titleLabel, TitleVerticalAlignment),
+                                new StackLayoutItem
+                                {
+                                    VerticalAlignment = TitleVerticalAlignment,
+                                    Control = new Label
+                                    {
+                                        Text = this.Text,
+                                        Font = Fonts.Cached("Sans", 9, FontStyle.Bold)
+                                    }
+                                },
                                 new StackLayoutItem(this.Content, ExpandContent)
                             }
                         }
@@ -101,7 +100,15 @@ namespace OpenTabletDriver.UX.Controls.Generic
                         Padding = ContentPadding,
                         Items =
                         {
-                            new StackLayoutItem(titleLabel, TitleHorizontalAlignment),
+                            new StackLayoutItem
+                            {
+                                HorizontalAlignment = TitleHorizontalAlignment,
+                                Control = new Label
+                                {
+                                    Text = this.Text,
+                                    Font = Fonts.Cached("Sans", 9, FontStyle.Bold)
+                                }
+                            },
                             new StackLayoutItem
                             {
                                 Expand = true,

--- a/OpenTabletDriver/Reflection/PluginManager.cs
+++ b/OpenTabletDriver/Reflection/PluginManager.cs
@@ -43,23 +43,24 @@ namespace OpenTabletDriver.Reflection
             {
                 try
                 {
-                    var type = PluginTypes.FirstOrDefault(t => t.FullName == name);
-                    var matchingConstructors = from ctor in type?.GetConstructors()
+                    if (PluginTypes.FirstOrDefault(t => t.FullName == name) is TypeInfo type)
+                    {
+                        var matchingConstructors = from ctor in type.GetConstructors()
                         let parameters = ctor.GetParameters()
                         where parameters.Length == args.Length
                         where IsValidParameterFor(args, parameters)
                         select ctor;
 
-                    var constructor = matchingConstructors.FirstOrDefault();
-                    if (constructor == null)
-                        Log.Write("Plugin", $"No matching constructor found for '{name}'", LogLevel.Debug);
-                    return (T)constructor?.Invoke(args) ?? null;
+                        if (matchingConstructors.FirstOrDefault() is ConstructorInfo constructor)
+                            return (T)constructor.Invoke(args) ?? null;
+                    }
                 }
                 catch
                 {
                     Log.Write("Plugin", $"Unable to construct object '{name}'", LogLevel.Error);
                 }
             }
+            Log.Write("Plugin", $"No constructor found for '{name}'", LogLevel.Debug);
             return null;
         }
 


### PR DESCRIPTION
# Changes
- Don't construct unused label object in Group control (macOS)
- Handle null token type in `PluginSetting.GetValue<T>()`

# Issues
- Closes #555