### PR TITLE
Use HPET-enabled Stopwatch class

### DIFF
--- a/OpenTabletDriver.Plugin/HPETDeltaStopwatch.cs
+++ b/OpenTabletDriver.Plugin/HPETDeltaStopwatch.cs
@@ -1,21 +1,19 @@
 using System;
 using System.Diagnostics;
 
-namespace OpenTabletDriver.Plugin.Utils
+namespace OpenTabletDriver.Plugin.Timing
 {
-    public class DeltaStopwatch
+    public class HPETDeltaStopwatch
     {
-        public DeltaStopwatch(bool startRunning = true)
+        public HPETDeltaStopwatch(bool startRunning = true)
         {
             isRunning = startRunning;
             start = isRunning ? internalWatch.Elapsed : default;
         }
 
         public static TimeSpan RunitmeElapsed => internalWatch.Elapsed;
-        public static double RuntimeElapsedMs => RunitmeElapsed.TotalMilliseconds;
 
         public TimeSpan Elapsed => isRunning ? internalWatch.Elapsed - start : end - start;
-        public double ElapsedMs => Elapsed.TotalMilliseconds;
 
         public void Start()
         {
@@ -42,7 +40,6 @@ namespace OpenTabletDriver.Plugin.Utils
                 return delta;
             }
         }
-        public double RestartMs() => Restart().TotalMilliseconds;
 
         public TimeSpan Stop()
         {
@@ -53,7 +50,6 @@ namespace OpenTabletDriver.Plugin.Utils
             }
             return end - start;
         }
-        public double StopMs() => Stop().TotalMilliseconds;
 
         public TimeSpan Reset()
         {
@@ -61,7 +57,6 @@ namespace OpenTabletDriver.Plugin.Utils
             start = end = default;
             return delta;
         }
-        public double ResetMs() => Reset().TotalMilliseconds;
 
         private static Stopwatch internalWatch = Stopwatch.StartNew();
         protected TimeSpan start;

--- a/OpenTabletDriver.Plugin/Output/RelativeOutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/RelativeOutputMode.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Numerics;
 using OpenTabletDriver.Plugin.Attributes;
@@ -13,7 +14,7 @@ namespace OpenTabletDriver.Plugin.Output
     {
         private IList<IFilter> filters, preFilters, postFilters;
         private Vector2? lastPos;
-        private DateTime lastReceived;
+        private Stopwatch stopwatch = new Stopwatch();
         private Matrix3x2 transformationMatrix;
 
         public IList<IFilter> Filters
@@ -67,7 +68,7 @@ namespace OpenTabletDriver.Plugin.Output
 
         private void UpdateTransformMatrix()
         {
-            this.lastReceived = default;  // Prevents cursor from jumping on sensitivity change
+            this.stopwatch.Reset();     // Prevents cursor from jumping on sensitivity change
 
             this.transformationMatrix = Matrix3x2.CreateRotation(
                 (float)(-Rotation * System.Math.PI / 180));
@@ -93,8 +94,8 @@ namespace OpenTabletDriver.Plugin.Output
 
         public Vector2? Transpose(ITabletReport report)
         {
-            var difference = DateTime.Now - this.lastReceived;
-            this.lastReceived = DateTime.Now;
+            var elapsed = stopwatch.Elapsed;
+            stopwatch.Restart();
 
             var pos = report.Position;
 
@@ -111,7 +112,7 @@ namespace OpenTabletDriver.Plugin.Output
             var delta = pos - this.lastPos;
             this.lastPos = pos;
 
-            return (difference > ResetTime) ? null : delta;
+            return (elapsed > ResetTime || elapsed.Ticks != 0) ? null : delta;
         }
     }
 }

--- a/OpenTabletDriver.Plugin/Output/RelativeOutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/RelativeOutputMode.cs
@@ -1,26 +1,20 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Numerics;
 using OpenTabletDriver.Plugin.Attributes;
 using OpenTabletDriver.Plugin.Platform.Pointer;
 using OpenTabletDriver.Plugin.Tablet;
+using OpenTabletDriver.Plugin.Utils;
 
 namespace OpenTabletDriver.Plugin.Output
 {
     [PluginIgnore]
     public abstract class RelativeOutputMode : IOutputMode
     {
-        public RelativeOutputMode()
-        {
-            stopwatch.Start();
-        }
-        
         private IList<IFilter> filters, preFilters, postFilters;
         private Vector2? lastPos;
-        private Stopwatch stopwatch = new Stopwatch();
-        private TimeSpan lastElapsed = default;
+        private DeltaStopwatch stopwatch = new DeltaStopwatch(true);
         private bool skipReport = false;
         private Matrix3x2 transformationMatrix;
 
@@ -101,9 +95,7 @@ namespace OpenTabletDriver.Plugin.Output
 
         public Vector2? Transpose(ITabletReport report)
         {
-            var currElapsed = stopwatch.Elapsed;
-            var deltaTime = currElapsed - lastElapsed;
-            lastElapsed = currElapsed;
+            var deltaTime = stopwatch.Restart();
 
             var pos = report.Position;
 

--- a/OpenTabletDriver.Plugin/Output/RelativeOutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/RelativeOutputMode.cs
@@ -5,7 +5,7 @@ using System.Numerics;
 using OpenTabletDriver.Plugin.Attributes;
 using OpenTabletDriver.Plugin.Platform.Pointer;
 using OpenTabletDriver.Plugin.Tablet;
-using OpenTabletDriver.Plugin.Utils;
+using OpenTabletDriver.Plugin.Timing;
 
 namespace OpenTabletDriver.Plugin.Output
 {
@@ -14,7 +14,7 @@ namespace OpenTabletDriver.Plugin.Output
     {
         private IList<IFilter> filters, preFilters, postFilters;
         private Vector2? lastPos;
-        private DeltaStopwatch stopwatch = new DeltaStopwatch(true);
+        private HPETDeltaStopwatch stopwatch = new HPETDeltaStopwatch(true);
         private bool skipReport = false;
         private Matrix3x2 transformationMatrix;
 

--- a/OpenTabletDriver.Plugin/Tablet/Interpolator/Interpolator.cs
+++ b/OpenTabletDriver.Plugin/Tablet/Interpolator/Interpolator.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using OpenTabletDriver.Plugin.Attributes;
 using OpenTabletDriver.Plugin.Timers;
-using OpenTabletDriver.Plugin.Utils;
+using OpenTabletDriver.Plugin.Timing;
 
 namespace OpenTabletDriver.Plugin.Tablet.Interpolator
 {
@@ -22,7 +22,7 @@ namespace OpenTabletDriver.Plugin.Tablet.Interpolator
         protected double reportMsAvg = 5.0f;
         protected bool enabled;
         protected ITimer scheduler;
-        protected DeltaStopwatch reportStopwatch = new DeltaStopwatch(true);
+        protected HPETDeltaStopwatch reportStopwatch = new HPETDeltaStopwatch(true);
         protected readonly object stateLock = new object();
 
         protected bool inRange;
@@ -70,7 +70,7 @@ namespace OpenTabletDriver.Plugin.Tablet.Interpolator
                 {
                     lock (this.stateLock)
                     {
-                        this.reportMsAvg += (reportStopwatch.RestartMs() - reportMsAvg) / 10.0f;
+                        this.reportMsAvg += (reportStopwatch.Restart().TotalMilliseconds - reportMsAvg) / 10.0f;
                         this.InRange = true;
 
                         if (Enabled)
@@ -94,7 +94,7 @@ namespace OpenTabletDriver.Plugin.Tablet.Interpolator
             lock (this.stateLock)
             {
                 var limit = Limiter.Transform(this.reportMsAvg);
-                if ((reportStopwatch.ElapsedMs < limit) && this.InRange)
+                if ((reportStopwatch.Elapsed.TotalMilliseconds < limit) && this.InRange)
                 {
                     var report = Interpolate();
                     Info.Driver.HandleReport(report);

--- a/OpenTabletDriver.Plugin/Utils/DeltaStopwatch.cs
+++ b/OpenTabletDriver.Plugin/Utils/DeltaStopwatch.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Diagnostics;
+
+namespace OpenTabletDriver.Plugin.Utils
+{
+    public class DeltaStopwatch
+    {
+        public DeltaStopwatch(bool startRunning = true)
+        {
+            isRunning = startRunning;
+            start = isRunning ? internalWatch.Elapsed : default;
+        }
+
+        public static TimeSpan RunitmeElapsed => internalWatch.Elapsed;
+        public static double RuntimeElapsedMs => RunitmeElapsed.TotalMilliseconds;
+
+        public TimeSpan Elapsed => isRunning ? internalWatch.Elapsed - start : end - start;
+        public double ElapsedMs => Elapsed.TotalMilliseconds;
+
+        public void Start()
+        {
+            if (!isRunning)
+            {
+                isRunning = true;
+                start = internalWatch.Elapsed;
+            }
+        }
+
+        public TimeSpan Restart()
+        {
+            if (isRunning)
+            {
+                var current = internalWatch.Elapsed;
+                var delta = current - start;
+                start = current;
+                return delta;
+            }
+            else
+            {
+                var delta = end - start;
+                Start();
+                return delta;
+            }
+        }
+        public double RestartMs() => Restart().TotalMilliseconds;
+
+        public TimeSpan Stop()
+        {
+            if (isRunning)
+            {
+                isRunning = false;
+                end = internalWatch.Elapsed;
+            }
+            return end - start;
+        }
+        public double StopMs() => Stop().TotalMilliseconds;
+
+        public TimeSpan Reset()
+        {
+            var delta = Stop();
+            start = end = default;
+            return delta;
+        }
+        public double ResetMs() => Reset().TotalMilliseconds;
+
+        private static Stopwatch internalWatch = Stopwatch.StartNew();
+        protected TimeSpan start;
+        protected TimeSpan end;
+        protected bool isRunning;
+    }
+}

--- a/OpenTabletDriver.UX/Windows/TabletDebugger.cs
+++ b/OpenTabletDriver.UX/Windows/TabletDebugger.cs
@@ -1,8 +1,8 @@
 ﻿using System;
-using System.Diagnostics;
 using Eto.Drawing;
 using Eto.Forms;
 using OpenTabletDriver.Plugin.Tablet;
+using OpenTabletDriver.Plugin.Utils;
 using OpenTabletDriver.Tablet;
 using OpenTabletDriver.UX.Controls.Generic;
 
@@ -53,7 +53,6 @@ namespace OpenTabletDriver.UX.Windows
                 }
             };
 
-            stopwatch.Start();
             InitializeAsync();
         }
 
@@ -72,16 +71,13 @@ namespace OpenTabletDriver.UX.Windows
 
         private TextGroup rawTabletBox, tabletBox, rawAuxBox, auxBox, reportRateBox;
         private double reportPeriod;
-        private Stopwatch stopwatch = new Stopwatch();
-        protected TimeSpan lastElapsed = default;
+        private DeltaStopwatch stopwatch = new DeltaStopwatch(true);
 
         private void HandleReport(object sender, IDeviceReport report)
         {
             if (report is ITabletReport tabletReport)
             {
-                var currElapsed = stopwatch.Elapsed;
-                reportPeriod += ((currElapsed - lastElapsed).TotalMilliseconds - reportPeriod) / 10.0f;
-                lastElapsed = currElapsed;
+                reportPeriod += (stopwatch.RestartMs() - reportPeriod) / 10.0f;
 
                 rawTabletBox.Update(tabletReport?.StringFormat(true));
                 tabletBox.Update(tabletReport?.StringFormat(false).Replace(", ", Environment.NewLine));

--- a/OpenTabletDriver.UX/Windows/TabletDebugger.cs
+++ b/OpenTabletDriver.UX/Windows/TabletDebugger.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using Eto.Drawing;
 using Eto.Forms;
 using OpenTabletDriver.Plugin.Tablet;
@@ -69,20 +70,20 @@ namespace OpenTabletDriver.UX.Windows
         }
 
         private TextGroup rawTabletBox, tabletBox, rawAuxBox, auxBox, reportRateBox;
-        private float reportRate;
-        private DateTime lastTime = DateTime.UtcNow;
+        private double reportPeriod;
+        private Stopwatch stopwatch = new Stopwatch();
 
         private void HandleReport(object sender, IDeviceReport report)
         {
             if (report is ITabletReport tabletReport)
             {
                 var now = DateTime.UtcNow;
-                reportRate += (float)(((now - lastTime).TotalMilliseconds - reportRate) / 50);
-                lastTime = now;
+                reportPeriod += (stopwatch.Elapsed.TotalMilliseconds - reportPeriod) / 10.0f;
+                stopwatch.Restart();
 
                 rawTabletBox.Update(tabletReport?.StringFormat(true));
                 tabletBox.Update(tabletReport?.StringFormat(false).Replace(", ", Environment.NewLine));
-                reportRateBox.Update($"{(uint)(1000 / reportRate)}hz");
+                reportRateBox.Update($"{(uint)(1000 / reportPeriod)}hz");
             }
             if (report is IAuxReport auxReport)
             {

--- a/OpenTabletDriver.UX/Windows/TabletDebugger.cs
+++ b/OpenTabletDriver.UX/Windows/TabletDebugger.cs
@@ -53,6 +53,7 @@ namespace OpenTabletDriver.UX.Windows
                 }
             };
 
+            stopwatch.Start();
             InitializeAsync();
         }
 
@@ -72,14 +73,15 @@ namespace OpenTabletDriver.UX.Windows
         private TextGroup rawTabletBox, tabletBox, rawAuxBox, auxBox, reportRateBox;
         private double reportPeriod;
         private Stopwatch stopwatch = new Stopwatch();
+        protected TimeSpan lastElapsed = default;
 
         private void HandleReport(object sender, IDeviceReport report)
         {
             if (report is ITabletReport tabletReport)
             {
-                var now = DateTime.UtcNow;
-                reportPeriod += (stopwatch.Elapsed.TotalMilliseconds - reportPeriod) / 10.0f;
-                stopwatch.Restart();
+                var currElapsed = stopwatch.Elapsed;
+                reportPeriod += ((currElapsed - lastElapsed).TotalMilliseconds - reportPeriod) / 10.0f;
+                lastElapsed = currElapsed;
 
                 rawTabletBox.Update(tabletReport?.StringFormat(true));
                 tabletBox.Update(tabletReport?.StringFormat(false).Replace(", ", Environment.NewLine));

--- a/OpenTabletDriver.UX/Windows/TabletDebugger.cs
+++ b/OpenTabletDriver.UX/Windows/TabletDebugger.cs
@@ -2,7 +2,7 @@
 using Eto.Drawing;
 using Eto.Forms;
 using OpenTabletDriver.Plugin.Tablet;
-using OpenTabletDriver.Plugin.Utils;
+using OpenTabletDriver.Plugin.Timing;
 using OpenTabletDriver.Tablet;
 using OpenTabletDriver.UX.Controls.Generic;
 
@@ -71,13 +71,13 @@ namespace OpenTabletDriver.UX.Windows
 
         private TextGroup rawTabletBox, tabletBox, rawAuxBox, auxBox, reportRateBox;
         private double reportPeriod;
-        private DeltaStopwatch stopwatch = new DeltaStopwatch(true);
+        private HPETDeltaStopwatch stopwatch = new HPETDeltaStopwatch(true);
 
         private void HandleReport(object sender, IDeviceReport report)
         {
             if (report is ITabletReport tabletReport)
             {
-                reportPeriod += (stopwatch.RestartMs() - reportPeriod) / 10.0f;
+                reportPeriod += (stopwatch.Restart().TotalMilliseconds - reportPeriod) / 10.0f;
 
                 rawTabletBox.Update(tabletReport?.StringFormat(true));
                 tabletBox.Update(tabletReport?.StringFormat(false).Replace(", ", Environment.NewLine));


### PR DESCRIPTION
It replaces DateTime.Now in ms-critical sections,
as per .net documentation, DateTime.Now's resolution
can have an impact on sub 100ms time intervals.
https://docs.microsoft.com/en-us/dotnet/api/system.datetime?view=net-5.0#datetime-resolution