### PR TITLE
Completely specify the buggy G430 revision

### DIFF
--- a/OpenTabletDriver/Configurations/XP-Pen/G430.json
+++ b/OpenTabletDriver/Configurations/XP-Pen/G430.json
@@ -21,7 +21,7 @@
       "FeatureInitReport": null,
       "OutputInitReport": "ArAC",
       "DeviceStrings": {
-        "4": "V2\\.0"
+        "4": "V2\\.0 20170423"
       },
       "InitializationStrings": []
     },


### PR DESCRIPTION
The G430 with 10160LPI spec is most likely specific to the certain revision that it was found