### PR TITLE
Improve RPC recovery and support multi-client

### DIFF
--- a/OpenTabletDriver.Daemon/Program.cs
+++ b/OpenTabletDriver.Daemon/Program.cs
@@ -60,7 +60,7 @@ namespace OpenTabletDriver.Daemon
                 var host = new RpcHost<DriverDaemon>("OpenTabletDriver.Daemon");
                 host.ConnectionStateChanged += (sender, state) => 
                     Log.Write("IPC", $"{(state ? "Connected to" : "Disconnected from")} a client.", LogLevel.Debug);
-                await Task.Delay(-1);
+                await host.Main();
             }
         }
     }

--- a/OpenTabletDriver.UX/App.cs
+++ b/OpenTabletDriver.UX/App.cs
@@ -56,7 +56,7 @@ namespace OpenTabletDriver.UX
         public const string PluginRepositoryUrl = "https://github.com/InfinityGhost/OpenTabletDriver/wiki/Plugin-Repository";
         public const string FaqUrl = "https://github.com/InfinityGhost/OpenTabletDriver/wiki#frequently-asked-questions";
 
-        public static RpcClient<IDriverDaemon> Driver { get; } = new("OpenTabletDriver.Daemon");
+        public static RpcClient<IDriverDaemon> Driver { get; } = new RpcClient<IDriverDaemon>("OpenTabletDriver.Daemon");
         public static Bitmap Logo => _logo.Value;
 
         public static event Action<Settings> SettingsChanged;
@@ -94,7 +94,7 @@ namespace OpenTabletDriver.UX
             _                       => false
         };
 
-        private static readonly Lazy<Bitmap> _logo = new(() =>
+        private static readonly Lazy<Bitmap> _logo = new Lazy<Bitmap>(() =>
         {
             var dataStream = Assembly.GetExecutingAssembly().GetManifestResourceStream("OpenTabletDriver.UX.Assets.otd.png");
             return new Bitmap(dataStream);

--- a/OpenTabletDriver.UX/App.cs
+++ b/OpenTabletDriver.UX/App.cs
@@ -56,7 +56,7 @@ namespace OpenTabletDriver.UX
         public const string PluginRepositoryUrl = "https://github.com/InfinityGhost/OpenTabletDriver/wiki/Plugin-Repository";
         public const string FaqUrl = "https://github.com/InfinityGhost/OpenTabletDriver/wiki#frequently-asked-questions";
 
-        public static RpcClient<IDriverDaemon> Driver => _daemon.Value;
+        public static RpcClient<IDriverDaemon> Driver { get; } = new("OpenTabletDriver.Daemon");
         public static Bitmap Logo => _logo.Value;
 
         public static event Action<Settings> SettingsChanged;
@@ -94,12 +94,7 @@ namespace OpenTabletDriver.UX
             _                       => false
         };
 
-        private static readonly Lazy<RpcClient<IDriverDaemon>> _daemon = new Lazy<RpcClient<IDriverDaemon>>(() =>
-        {
-            return new RpcClient<IDriverDaemon>("OpenTabletDriver.Daemon");
-        });
-
-        private static readonly Lazy<Bitmap> _logo = new Lazy<Bitmap>(() =>
+        private static readonly Lazy<Bitmap> _logo = new(() =>
         {
             var dataStream = Assembly.GetExecutingAssembly().GetManifestResourceStream("OpenTabletDriver.UX.Assets.otd.png");
             return new Bitmap(dataStream);

--- a/OpenTabletDriver.UX/DaemonWatchdog.cs
+++ b/OpenTabletDriver.UX/DaemonWatchdog.cs
@@ -41,11 +41,11 @@ namespace OpenTabletDriver.UX
 
         public void Start()
         {
-            this.daemonProcess = new()
+            this.daemonProcess = new Process()
             {
                 StartInfo = startInfo
             };
-            this.watchdogTimer = new(1000);
+            this.watchdogTimer = new Timer(1000);
 
             this.daemonProcess.Start();
             this.watchdogTimer.Start();

--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -26,6 +26,18 @@ namespace OpenTabletDriver.UX
             Content = ConstructPlaceholderControl();
             Menu = ConstructMenu();
 
+            Driver.Disconnected += (_, _) =>
+            {
+                Application.Instance.AsyncInvoke(async () =>
+                {
+                    var content = this.Content;
+                    Content = ConstructPlaceholderControl();
+                    await Driver.Connect();
+                    await LoadSettings(AppInfo.Current);
+                    Content = content;
+                });
+            };
+
             ApplyPlatformQuirks();
 
             InitializeAsync();
@@ -147,20 +159,6 @@ namespace OpenTabletDriver.UX
                 {
                     new StackLayoutItem(tabControl, HorizontalAlignment.Stretch, true),
                     new StackLayoutItem(commandsPanel, HorizontalAlignment.Right)
-                }
-            };
-        }
-
-        private Control ConstructAreaConfig(Control displayControl, Control tabletControl)
-        {
-            return new StackLayout
-            {
-                Visible = false,
-                Spacing = SystemInterop.CurrentPlatform == PluginPlatform.Windows ? 0 : 5,
-                Items =
-                {
-                    new StackLayoutItem(displayControl, HorizontalAlignment.Stretch, true),
-                    new StackLayoutItem(tabletControl, HorizontalAlignment.Stretch, true)
                 }
             };
         }
@@ -316,22 +314,27 @@ namespace OpenTabletDriver.UX
                     watchdog.Start();
                     watchdog.DaemonExited += (sender, e) =>
                     {
-                        var dialogResult = MessageBox.Show(
-                            this,
-                            "Fatal: The OpenTabletDriver Daemon has exited. Do you want to restart OpenTabletDriver?",
-                            "OpenTabletDriver Fatal Error",
-                            MessageBoxButtons.YesNo
-                        );
-                        switch (dialogResult)
+                        Application.Instance.AsyncInvoke(() =>
                         {
-                            case DialogResult.Yes:
-                                Application.Instance.Restart();
-                                break;
-                            case DialogResult.No:
-                            default:
-                                Application.Instance.Quit();
-                                break;
-                        }
+                            var dialogResult = MessageBox.Show(
+                                this,
+                                "Fatal: The OpenTabletDriver Daemon has exited. Do you want to restart it and reload OpenTabletDriver?",
+                                "OpenTabletDriver Fatal Error",
+                                MessageBoxButtons.YesNo,
+                                MessageBoxType.Error
+                            );
+                            switch (dialogResult)
+                            {
+                                case DialogResult.Yes:
+                                    watchdog.Dispose();
+                                    watchdog.Start();
+                                    break;
+                                case DialogResult.No:
+                                default:
+                                    Environment.Exit(0);
+                                    break;
+                            }
+                        });
                     };
                     this.Closing += (sender, e) =>
                     {
@@ -527,6 +530,12 @@ namespace OpenTabletDriver.UX
             stringReader.Show();
         }
 
+        private void ShowTabletDebugger()
+        {
+            var debugger = new TabletDebugger();
+            debugger.Show();
+        }
+
         private async Task ExportDiagnostics()
         {
             var log = await Driver.Instance.GetCurrentLog();
@@ -551,12 +560,6 @@ namespace OpenTabletDriver.UX
                         await sw.WriteLineAsync(diagnosticDump.ToString());
                     break;
             }
-        }
-
-        private void ShowTabletDebugger()
-        {
-            var debugger = new TabletDebugger();
-            debugger.Show();
         }
     }
 }


### PR DESCRIPTION
## Changes

- Allow multiple clients (Fixes `OpenTabletDriver.Console` when UX is active)
- Show "Connecting to Daemon..." when UX got disconnected from Daemon, and attempt reconnect + refresh
- If Daemon died and UX handles Daemon, prompt user for a restart of Daemon (watchdog logic reused) and a reload of UX (reconnection logic above reused)
- Fixed a situation where clients can't connect to Daemon due to an error from previous client
- Only allow server-client connections from the same user