### PR TITLE
Allow only one instance of UX

### DIFF
--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -50,11 +50,13 @@ namespace OpenTabletDriver.Daemon
             await LoadPlugins();
             await DetectTablets();
 
+            uxRpc = new RpcClient<IUXDriver>("OpenTabletDriver.UX");
+
             Info.GetUXInstance = async () =>
             {
-                var rpc = new RpcClient<IUXDriver>("OpenTabletDriver.UX");
-                await rpc.Connect();
-                return rpc.Instance;
+                if (!uxRpc.IsConnected)
+                    await uxRpc.Connect();
+                return uxRpc.Instance;
             };
 
             var appdataDir = new DirectoryInfo(AppInfo.Current.AppDataDirectory);
@@ -73,6 +75,8 @@ namespace OpenTabletDriver.Daemon
             else
                 await ResetSettings();
         }
+
+        protected RpcClient<IUXDriver> uxRpc;
 
         public event EventHandler<LogMessage> Message;
         public event EventHandler<DebugTabletReport> TabletReport;

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -15,6 +15,7 @@ using OpenTabletDriver.Desktop.Migration;
 using OpenTabletDriver.Desktop.Output;
 using OpenTabletDriver.Desktop.Reflection;
 using OpenTabletDriver.Desktop.Reflection.Metadata;
+using OpenTabletDriver.Desktop.RPC;
 using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.Logging;
 using OpenTabletDriver.Plugin.Output;
@@ -48,6 +49,13 @@ namespace OpenTabletDriver.Daemon
             AppInfo.PluginManager.Clean();
             await LoadPlugins();
             await DetectTablets();
+
+            Info.GetUXInstance = async () =>
+            {
+                var rpc = new RpcClient<IUXDriver>("OpenTabletDriver.UX");
+                await rpc.Connect();
+                return rpc.Instance;
+            };
 
             var appdataDir = new DirectoryInfo(AppInfo.Current.AppDataDirectory);
             if (!appdataDir.Exists)

--- a/OpenTabletDriver.Desktop/Binding/UXBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/UXBinding.cs
@@ -1,0 +1,41 @@
+using System;
+using OpenTabletDriver.Plugin;
+using OpenTabletDriver.Plugin.Attributes;
+
+namespace OpenTabletDriver.Desktop.Binding
+{
+    [PluginName("UX Binding")]
+    public class UXBinding : IBinding, IValidateBinding
+    {
+        public string[] ValidProperties => new string[]
+        {
+            "Show Window"
+        };
+
+        [Property("Property")]
+        public string Property { get; set; }
+
+        public Action Press => async () =>
+        {
+            switch (Property)
+            {
+                case "Show Window":
+                    try
+                    {
+                        var ux = await Info.GetUXInstance();
+                        await ux.ShowClient();
+                    }
+                    catch { }
+                    break;
+
+                default:
+                    break;
+            }
+        };
+
+        public Action Release => () =>
+        {
+
+        };
+    }
+}

--- a/OpenTabletDriver.Desktop/Binding/UXBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/UXBinding.cs
@@ -33,9 +33,6 @@ namespace OpenTabletDriver.Desktop.Binding
             }
         };
 
-        public Action Release => () =>
-        {
-
-        };
+        public Action Release => () => { };
     }
 }

--- a/OpenTabletDriver.Desktop/RPC/RpcClient.cs
+++ b/OpenTabletDriver.Desktop/RPC/RpcClient.cs
@@ -13,6 +13,7 @@ namespace OpenTabletDriver.Desktop.RPC
 
         public T Instance { private set; get; }
         public event EventHandler Disconnected;
+        public bool IsConnected { private set; get; }
 
         public RpcClient(string pipeName)
         {
@@ -28,8 +29,11 @@ namespace OpenTabletDriver.Desktop.RPC
             this.Instance = this.rpc.Attach<T>();
             rpc.StartListening();
 
+            this.IsConnected = true;
+
             rpc.Disconnected += (_, _) =>
             {
+                this.IsConnected = false;
                 this.stream.Dispose();
                 Disconnected?.Invoke(this, null);
                 rpc.Dispose();

--- a/OpenTabletDriver.Plugin/IUXDriver.cs
+++ b/OpenTabletDriver.Plugin/IUXDriver.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace OpenTabletDriver.Plugin
+{
+    public interface IUXDriver
+    {
+        Task ShowClient();
+    }
+}

--- a/OpenTabletDriver.Plugin/Info.cs
+++ b/OpenTabletDriver.Plugin/Info.cs
@@ -1,11 +1,13 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace OpenTabletDriver.Plugin
 {
     public static class Info
     {
         public static IDriver Driver => GetDriverInstance();
-        
+
+        public static Func<Task<IUXDriver>> GetUXInstance { set; get; }
         public static Func<IDriver> GetDriverInstance { set; get; }
     }
 }

--- a/OpenTabletDriver.UX/App.cs
+++ b/OpenTabletDriver.UX/App.cs
@@ -17,6 +17,13 @@ namespace OpenTabletDriver.UX
     {
         public static void Run(string platform, string[] args)
         {
+            _ = UXInstance.Invoke(async ux =>
+            {
+                await ux.ShowClient();
+                UXInstance.Dispose();
+                Environment.Exit(0);
+            });
+
             var root = new RootCommand("OpenTabletDriver UX")
             {
                 new Option<bool>(new string[] { "-m", "--minimized" }, "Start the application minimized")
@@ -53,9 +60,9 @@ namespace OpenTabletDriver.UX
             app.Run(mainForm);
         }
 
-        public const string PluginRepositoryUrl = "https://github.com/InfinityGhost/OpenTabletDriver/wiki/Plugin-Repository";
         public const string FaqUrl = "https://github.com/InfinityGhost/OpenTabletDriver/wiki#frequently-asked-questions";
 
+        private static UXInstance UXInstance = new UXInstance();
         public static RpcClient<IDriverDaemon> Driver { get; } = new RpcClient<IDriverDaemon>("OpenTabletDriver.Daemon");
         public static Bitmap Logo => _logo.Value;
 

--- a/OpenTabletDriver.UX/RPC/UXDriver.cs
+++ b/OpenTabletDriver.UX/RPC/UXDriver.cs
@@ -1,0 +1,23 @@
+using System.Threading.Tasks;
+using Eto.Forms;
+using OpenTabletDriver.Plugin;
+
+namespace OpenTabletDriver.UX.RPC
+{
+    public class UXDriver : IUXDriver
+    {
+        public async Task ShowClient()
+        {
+            await Application.Instance.InvokeAsync(() =>
+            {
+                if (Application.Instance?.MainForm is Form form)
+                {
+                    form.Show();
+                    form.WindowState = WindowState.Normal;
+                    form.BringToFront();
+                    form.WindowStyle = WindowStyle.Default;
+                }
+            });
+        }
+    }
+}

--- a/OpenTabletDriver.UX/UXInstance.cs
+++ b/OpenTabletDriver.UX/UXInstance.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using OpenTabletDriver.Desktop.RPC;
+using OpenTabletDriver.Plugin;
+using OpenTabletDriver.UX.RPC;
+
+namespace OpenTabletDriver.UX
+{
+    public class UXInstance : IDisposable
+    {
+        readonly Instance Instance = new Instance("OpenTabletDriver.UX.Instance");
+        readonly RpcHost<UXDriver> Host;
+        readonly RpcClient<IUXDriver> Client;
+        readonly bool IsClient;
+
+        public UXInstance()
+        {
+            if (!Instance.AlreadyExists)
+            {
+                Host = new RpcHost<UXDriver>("OpenTabletDriver.UX");
+                IsClient = false;
+            }
+            else
+            {
+                Client = new RpcClient<IUXDriver>("OpenTabletDriver.UX");
+                IsClient = true;
+            }
+        }
+
+        public async Task Invoke(Func<IUXDriver, Task> action)
+        {
+            if (IsClient)
+            {
+                await Client.Connect();
+                await action(Client.Instance);
+            }
+            else
+            {
+                var thread = new Thread(async () => await Host.Main())
+                {
+                    IsBackground = true
+                };
+                thread.Start();
+            }
+        }
+
+        public void Dispose()
+        {
+            Instance?.Dispose();
+            GC.SuppressFinalize(this);
+        }
+    }
+}


### PR DESCRIPTION
## Changes

- Single instance UX
- `Info.GeUXInstance()`
- New binding `UXBinding : "Show Window"`

Code were structured for easy addition of new capabilities that may be invoked from `RpcClient<IUXDriver>` (requesting for better interface name).

Plugins may use that proxy object to invoke methods to run on UX thread.

## Issues

Fixes #479