### PR TITLE
Change Area Converter labels accordingly

### DIFF
--- a/OpenTabletDriver.Desktop/Conversion/ConversionFactorAreaConverter.cs
+++ b/OpenTabletDriver.Desktop/Conversion/ConversionFactorAreaConverter.cs
@@ -11,8 +11,8 @@ namespace OpenTabletDriver.Desktop.Conversion
         public virtual DeviceVendor Vendor => DeviceVendor.Wacom & DeviceVendor.VEIKK;
 
         public string Top => "Top";
-        public string Bottom => "Bottom";
         public string Left => "Left";
+        public string Bottom => "Bottom";
         public string Right => "Right";
 
         protected double GetConversionFactor(TabletState tablet)
@@ -21,7 +21,7 @@ namespace OpenTabletDriver.Desktop.Conversion
             return digitizer.MaxX / digitizer.Width;
         }
 
-        public Area Convert(TabletState tablet, double top, double bottom, double left, double right)
+        public Area Convert(TabletState tablet, double top, double left, double bottom, double right)
         {
             double conversionFactor = GetConversionFactor(tablet);
             var width = (right - left) / conversionFactor;

--- a/OpenTabletDriver.Desktop/Conversion/ConversionFactorAreaConverter.cs
+++ b/OpenTabletDriver.Desktop/Conversion/ConversionFactorAreaConverter.cs
@@ -7,16 +7,18 @@ namespace OpenTabletDriver.Desktop.Conversion
 {
     [PluginName("Wacom, VEIKK")]
     public class ConversionFactorAreaConverter : IAreaConverter
-    {        
+    {
         public virtual DeviceVendor Vendor => DeviceVendor.Wacom & DeviceVendor.VEIKK;
 
-        protected virtual double GetConversionFactor(TabletState tablet)
+        public string[] Label => new string[] { "Top", "Left", "Bottom", "Right" };
+
+        protected double GetConversionFactor(TabletState tablet)
         {
             var digitizer = tablet.Digitizer;
             return digitizer.MaxX / digitizer.Width;
         }
 
-        public Area Convert(TabletState tablet, double left, double top, double right, double bottom)
+        public Area Convert(TabletState tablet, double top, double left, double bottom, double right)
         {
             double conversionFactor = GetConversionFactor(tablet);
             var width = (right - left) / conversionFactor;

--- a/OpenTabletDriver.Desktop/Conversion/ConversionFactorAreaConverter.cs
+++ b/OpenTabletDriver.Desktop/Conversion/ConversionFactorAreaConverter.cs
@@ -10,7 +10,10 @@ namespace OpenTabletDriver.Desktop.Conversion
     {
         public virtual DeviceVendor Vendor => DeviceVendor.Wacom & DeviceVendor.VEIKK;
 
-        public string[] Label => new string[] { "Top", "Left", "Bottom", "Right" };
+        public string Top => "Top";
+        public string Bottom => "Bottom";
+        public string Left => "Left";
+        public string Right => "Right";
 
         protected double GetConversionFactor(TabletState tablet)
         {
@@ -18,7 +21,7 @@ namespace OpenTabletDriver.Desktop.Conversion
             return digitizer.MaxX / digitizer.Width;
         }
 
-        public Area Convert(TabletState tablet, double top, double left, double bottom, double right)
+        public Area Convert(TabletState tablet, double top, double bottom, double left, double right)
         {
             double conversionFactor = GetConversionFactor(tablet);
             var width = (right - left) / conversionFactor;

--- a/OpenTabletDriver.Desktop/Conversion/PercentageAreaConverter.cs
+++ b/OpenTabletDriver.Desktop/Conversion/PercentageAreaConverter.cs
@@ -10,7 +10,10 @@ namespace OpenTabletDriver.Desktop.Conversion
     {
         public virtual DeviceVendor Vendor => DeviceVendor.Huion & DeviceVendor.Gaomon;
 
-        public string[] Label => new string[] { "Up", "Left", "Down", "Right" };
+        public string Top => "Up";
+        public string Left => "Left";
+        public string Bottom => "Down";
+        public string Right => "Right";
 
         public Area Convert(TabletState tablet, double up, double left, double down, double right)
         {

--- a/OpenTabletDriver.Desktop/Conversion/PercentageAreaConverter.cs
+++ b/OpenTabletDriver.Desktop/Conversion/PercentageAreaConverter.cs
@@ -10,14 +10,16 @@ namespace OpenTabletDriver.Desktop.Conversion
     {
         public virtual DeviceVendor Vendor => DeviceVendor.Huion & DeviceVendor.Gaomon;
 
-        public Area Convert(TabletState tablet, double left, double top, double right, double bottom)
+        public string[] Label => new string[] { "Up", "Left", "Down", "Right" };
+
+        public Area Convert(TabletState tablet, double up, double left, double down, double right)
         {
             var digitizer = tablet.Digitizer;
 
             var width = (right - left) * digitizer.Width;
-            var height = (bottom - top) * digitizer.Height;
+            var height = (down - up) * digitizer.Height;
             var offsetX = (width / 2) + (left * digitizer.Width);
-            var offsetY = (height / 2) + (top * digitizer.Height);
+            var offsetY = (height / 2) + (up * digitizer.Height);
 
             return new Area((float)width, (float)height, new Vector2((float)offsetX, (float)offsetY), 0f);
         }

--- a/OpenTabletDriver.Desktop/Conversion/XP_PenDriverAreaConverter.cs
+++ b/OpenTabletDriver.Desktop/Conversion/XP_PenDriverAreaConverter.cs
@@ -10,15 +10,17 @@ namespace OpenTabletDriver.Desktop.Conversion
     {
         public virtual DeviceVendor Vendor => DeviceVendor.XP_Pen;
 
-        public const float XP_PEN_AREA_CONSTANT = 3.937f;
+        public string[] Label => new string[] { "W", "X", "H", "Y" };
 
-        public Area Convert(TabletState tablet, double left, double top, double right, double bottom)
+        private const float XP_PEN_AREA_CONSTANT = 3.937f;
+
+        public Area Convert(TabletState tablet, double w, double x, double h, double y)
         {
             double conversionFactor = XP_PEN_AREA_CONSTANT;
-            var width = top / conversionFactor;
-            var height = left / conversionFactor;
-            var offsetX = (width / 2) + (bottom / conversionFactor);
-            var offsetY = (height / 2) + (right / conversionFactor);
+            var width = w / conversionFactor;
+            var height = h / conversionFactor;
+            var offsetX = (width / 2) + (x / conversionFactor);
+            var offsetY = (height / 2) + (y / conversionFactor);
 
             return new Area((float)width, (float)height, new Vector2((float)offsetX, (float)offsetY), 0f);
         }

--- a/OpenTabletDriver.Desktop/Conversion/XP_PenDriverAreaConverter.cs
+++ b/OpenTabletDriver.Desktop/Conversion/XP_PenDriverAreaConverter.cs
@@ -10,11 +10,14 @@ namespace OpenTabletDriver.Desktop.Conversion
     {
         public virtual DeviceVendor Vendor => DeviceVendor.XP_Pen;
 
-        public string[] Label => new string[] { "W", "X", "H", "Y" };
+        public string Top => "W";
+        public string Left => "H";
+        public string Bottom => "X";
+        public string Right => "Y";
 
         private const float XP_PEN_AREA_CONSTANT = 3.937f;
 
-        public Area Convert(TabletState tablet, double w, double x, double h, double y)
+        public Area Convert(TabletState tablet, double w, double h, double x, double y)
         {
             double conversionFactor = XP_PEN_AREA_CONSTANT;
             var width = w / conversionFactor;

--- a/OpenTabletDriver.Plugin/Tablet/IAreaConverter.cs
+++ b/OpenTabletDriver.Plugin/Tablet/IAreaConverter.cs
@@ -4,6 +4,8 @@ namespace OpenTabletDriver.Plugin.Tablet
     {
         DeviceVendor Vendor { get; }
 
+        string[] Label { get; }
+
         Area Convert(TabletState tablet, double left, double top, double right, double bottom);
     }
 }

--- a/OpenTabletDriver.Plugin/Tablet/IAreaConverter.cs
+++ b/OpenTabletDriver.Plugin/Tablet/IAreaConverter.cs
@@ -4,8 +4,11 @@ namespace OpenTabletDriver.Plugin.Tablet
     {
         DeviceVendor Vendor { get; }
 
-        string[] Label { get; }
+        string Top { get; }
+        string Left { get; }
+        string Bottom { get; }
+        string Right { get; }
 
-        Area Convert(TabletState tablet, double left, double top, double right, double bottom);
+        Area Convert(TabletState tablet, double top, double left, double bottom, double right);
     }
 }

--- a/OpenTabletDriver.UX/Controls/Generic/Group.cs
+++ b/OpenTabletDriver.UX/Controls/Generic/Group.cs
@@ -15,8 +15,8 @@ namespace OpenTabletDriver.UX.Controls.Generic
         public Group(string text, Control content, Orientation orientation = DEFAULT_ORIENTATION, bool expand = true)
             : this()
         {
-            this.text = text;
-            this.content = content;
+            this.Text = text;
+            this.Content = content;
             this.Orientation = orientation;
             this.ExpandContent = expand;
         }
@@ -57,6 +57,9 @@ namespace OpenTabletDriver.UX.Controls.Generic
 
         protected void UpdateControlLayout()
         {
+            if (!this.Loaded)
+                return;
+
             switch (Orientation, SystemInterop.CurrentPlatform)
             {
                 case (_, PluginPlatform.MacOS):

--- a/OpenTabletDriver.UX/Controls/Generic/Group.cs
+++ b/OpenTabletDriver.UX/Controls/Generic/Group.cs
@@ -15,8 +15,8 @@ namespace OpenTabletDriver.UX.Controls.Generic
         public Group(string text, Control content, Orientation orientation = DEFAULT_ORIENTATION, bool expand = true)
             : this()
         {
-            this.Text = text;
-            this.Content = content;
+            this.text = text;
+            this.content = content;
             this.Orientation = orientation;
             this.ExpandContent = expand;
         }
@@ -27,8 +27,17 @@ namespace OpenTabletDriver.UX.Controls.Generic
 
         protected virtual Color HorizontalBackgroundColor => SystemColors.ControlBackground;
         protected virtual Color VerticalBackgroundColor => SystemColors.WindowBackground;
-        
-        public string Text { set; get; }
+
+        private string text;
+        public string Text
+        {
+            set
+            {
+                this.text = value;
+                UpdateControlLayout();
+            }
+            get => text;
+        }
 
         private Control content;
         public new Control Content

--- a/OpenTabletDriver.UX/Controls/OutputModeEditor.cs
+++ b/OpenTabletDriver.UX/Controls/OutputModeEditor.cs
@@ -276,7 +276,7 @@ namespace OpenTabletDriver.UX.Controls
                 private async Task ConvertAreaDialog()
                 {
                     var converter = new AreaConverterDialog();
-                    await converter.ShowModalAsync();
+                    await converter.ShowModalAsync(Application.Instance.MainForm);
                 }
             }
         }

--- a/OpenTabletDriver.UX/Windows/AreaConverterDialog.cs
+++ b/OpenTabletDriver.UX/Windows/AreaConverterDialog.cs
@@ -27,20 +27,9 @@ namespace OpenTabletDriver.UX.Windows
 
         protected void RefreshLabel()
         {
-            IAreaConverter converter = null;
-            try
-            {
-                converter = converterList.ConstructSelectedType();
-            }
-            catch { }
-
-            if (converter != null)
-            {
-                foreach (var (group, text) in groups.Zip(converter.Label, (group, text) => (group, text)))
-                {
-                    group.Text = text;
-                }
-            }
+            var converter = converterList.ConstructSelectedType();
+            foreach (var (group, text) in groups.Zip(converter.Label, (group, text) => (group, text)))
+                group.Text = text;
         }
 
         protected async Task Refresh()

--- a/OpenTabletDriver.UX/Windows/AreaConverterDialog.cs
+++ b/OpenTabletDriver.UX/Windows/AreaConverterDialog.cs
@@ -28,8 +28,10 @@ namespace OpenTabletDriver.UX.Windows
         protected void RefreshLabel()
         {
             var converter = converterList.ConstructSelectedType();
-            foreach (var (group, text) in groups.Zip(converter.Label, (group, text) => (group, text)))
-                group.Text = text;
+            groups[0].Text = converter.Top;
+            groups[1].Text = converter.Bottom;
+            groups[2].Text = converter.Left;
+            groups[3].Text = converter.Right;
         }
 
         protected async Task Refresh()

--- a/OpenTabletDriver.UX/Windows/AreaConverterDialog.cs
+++ b/OpenTabletDriver.UX/Windows/AreaConverterDialog.cs
@@ -29,8 +29,8 @@ namespace OpenTabletDriver.UX.Windows
         {
             var converter = converterList.ConstructSelectedType();
             groups[0].Text = converter.Top;
-            groups[1].Text = converter.Bottom;
-            groups[2].Text = converter.Left;
+            groups[1].Text = converter.Left;
+            groups[2].Text = converter.Bottom;
             groups[3].Text = converter.Right;
         }
 


### PR DESCRIPTION
Also changed Group to update layout when changing `Group.Text`, and to avoid performing unneeded layout update during ctor by using the private member instead of the public property during ctor.