### PR TITLE
Ensure window visibility and launch Greeter at center position

### DIFF
--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -45,13 +45,12 @@ namespace OpenTabletDriver.UX
             InitializeAsync();
         }
 
-        private bool AlreadyShown;
         protected override void OnShown(EventArgs e)
         {
             base.OnShown(e);
 
             // Size and Location becomes available only during and after Shown event, LoadComplete don't have it yet
-            if (SystemInterop.CurrentPlatform == PluginPlatform.Windows && !this.AlreadyShown)
+            if (SystemInterop.CurrentPlatform == PluginPlatform.Windows && !this.alreadyShown)
             {
                 var bounds = Screen.FromPoint(this.Location + new Point(this.Size.Width / 2, this.Size.Height / 2)).Bounds;
                 var offset = new Point((int)bounds.X, (int)bounds.Y);
@@ -60,7 +59,7 @@ namespace OpenTabletDriver.UX
                 var x = Math.Min(Math.Max(0, this.Location.X), intersectRect.Width);
                 var y = Math.Min(Math.Max(0, this.Location.Y), intersectRect.Height);
                 this.Location = new Point(x, y) + offset;
-                this.AlreadyShown = true;
+                this.alreadyShown = true;
             }
         }
 
@@ -431,6 +430,7 @@ namespace OpenTabletDriver.UX
         private PluginSettingStoreCollectionEditor<IFilter> filterEditor;
         private PluginSettingStoreCollectionEditor<ITool> toolEditor;
         private PluginSettingStoreCollectionEditor<Interpolator> interpolatorEditor;
+        private bool alreadyShown;
 
         private async Task ResetSettings(bool force = true)
         {

--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -284,13 +284,18 @@ namespace OpenTabletDriver.UX
 
             if (SystemInterop.CurrentPlatform == PluginPlatform.Windows)
             {
-                var bounds = Screen.FromPoint(this.Location + new Point(this.ClientSize.Width / 2, this.ClientSize.Height / 2)).Bounds;
-                var offset = new Point((int)bounds.X, (int)bounds.Y);
-                var intersectRect = new Size((int)bounds.Width, (int)bounds.Height) - this.ClientSize;
+                void VisibilityCheck(object sender, EventArgs args)
+                {
+                    var bounds = Screen.FromPoint(this.Location + new Point(this.Size.Width / 2, this.Size.Height / 2)).Bounds;
+                    var offset = new Point((int)bounds.X, (int)bounds.Y);
+                    var intersectRect = new Size((int)bounds.Width, (int)bounds.Height) - this.Size;
 
-                var x = Math.Min(Math.Max(0, this.Location.X), intersectRect.Width);
-                var y = Math.Min(Math.Max(0, this.Location.Y), intersectRect.Height);
-                this.Location = new Point(x, y) + offset;
+                    var x = Math.Min(Math.Max(0, this.Location.X), intersectRect.Width);
+                    var y = Math.Min(Math.Max(0, this.Location.Y), intersectRect.Height);
+                    this.Location = new Point(x, y) + offset;
+                    this.Shown -= VisibilityCheck;
+                }
+                this.Shown += VisibilityCheck; // Size and Location becomes available only during and after Shown event, LoadComplete don't have it yet
             }
 
             bool enableDaemonWatchdog = SystemInterop.CurrentPlatform switch
@@ -532,8 +537,8 @@ namespace OpenTabletDriver.UX
 
         private async Task ShowFirstStartupGreeter()
         {
-            var greeter = new StartupGreeterWindow();
-            await greeter.ShowModalAsync(Application.Instance.MainForm);
+            var greeter = new StartupGreeterWindow(Application.Instance.MainForm);
+            await greeter.ShowModalAsync();
         }
 
         private void ShowConfigurationEditor()

--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -52,12 +52,11 @@ namespace OpenTabletDriver.UX
             // Size and Location becomes available only during and after Shown event, LoadComplete don't have it yet
             if (!this.alreadyShown)
             {
-                var bounds = Screen.FromPoint(this.Location + new Point(this.Size.Width / 2, this.Size.Height / 2)).Bounds;
-
-                if (this.WindowState == WindowState.Normal)
+                if (this.WindowState == WindowState.Normal && SystemInterop.CurrentPlatform != PluginPlatform.MacOS)
                 {
-                    var minWidth = Math.Min(SystemInterop.CurrentPlatform == PluginPlatform.MacOS ? 970 : 960, bounds.Width * 0.9);
-                    var minHeight = Math.Min(SystemInterop.CurrentPlatform == PluginPlatform.MacOS ? 770 : 760, bounds.Height * 0.9);
+                    var bounds = Screen.FromPoint(this.Location + new Point(this.Size.Width / 2, this.Size.Height / 2)).Bounds;
+                    var minWidth = Math.Min(960, bounds.Width * 0.9);
+                    var minHeight = Math.Min(760, bounds.Height * 0.9);
                     this.ClientSize = new Size((int)minWidth, (int)minHeight);
                     if (SystemInterop.CurrentPlatform == PluginPlatform.Windows)
                     {
@@ -312,6 +311,14 @@ namespace OpenTabletDriver.UX
                 PluginPlatform.MacOS   => true,
                 _                      => false,
             };
+
+            if (SystemInterop.CurrentPlatform == PluginPlatform.MacOS)
+            {
+                var bounds = Screen.PrimaryScreen.Bounds;
+                var minWidth = Math.Min(970, bounds.Width * 0.9);
+                var minHeight = Math.Min(770, bounds.Height * 0.9);
+                this.ClientSize = new Size((int)minWidth, (int)minHeight);
+            }
 
             if (App.EnableTrayIcon)
             {

--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -278,11 +278,20 @@ namespace OpenTabletDriver.UX
                 _                    => new Padding(0)
             };
 
-            this.ClientSize = SystemInterop.CurrentPlatform switch
+            var minWidth = Math.Min(SystemInterop.CurrentPlatform == PluginPlatform.MacOS ? 970 : 960, Screen.DisplayBounds.Width * 0.9);
+            var minHeight = Math.Min(SystemInterop.CurrentPlatform == PluginPlatform.MacOS ? 770 : 760, Screen.DisplayBounds.Height * 0.9);
+            this.ClientSize = new Size((int)minWidth, (int)minHeight);
+
+            if (SystemInterop.CurrentPlatform == PluginPlatform.Windows)
             {
-                PluginPlatform.MacOS => new Size(970, 770),
-                _ => new Size(960, 760)
-            };
+                var bounds = Screen.FromPoint(this.Location + new Point(this.ClientSize.Width / 2, this.ClientSize.Height / 2)).Bounds;
+                var offset = new Point((int)bounds.X, (int)bounds.Y);
+                var intersectRect = new Size((int)bounds.Width, (int)bounds.Height) - this.ClientSize;
+
+                var x = Math.Min(Math.Max(0, this.Location.X), intersectRect.Width);
+                var y = Math.Min(Math.Max(0, this.Location.Y), intersectRect.Height);
+                this.Location = new Point(x, y) + offset;
+            }
 
             bool enableDaemonWatchdog = SystemInterop.CurrentPlatform switch
             {
@@ -524,7 +533,7 @@ namespace OpenTabletDriver.UX
         private async Task ShowFirstStartupGreeter()
         {
             var greeter = new StartupGreeterWindow();
-            await greeter.ShowModalAsync();
+            await greeter.ShowModalAsync(Application.Instance.MainForm);
         }
 
         private void ShowConfigurationEditor()

--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -59,12 +59,15 @@ namespace OpenTabletDriver.UX
                     var minWidth = Math.Min(SystemInterop.CurrentPlatform == PluginPlatform.MacOS ? 970 : 960, bounds.Width * 0.9);
                     var minHeight = Math.Min(SystemInterop.CurrentPlatform == PluginPlatform.MacOS ? 770 : 760, bounds.Height * 0.9);
                     this.ClientSize = new Size((int)minWidth, (int)minHeight);
-                    var offset = new Point((int)bounds.X, (int)bounds.Y);
-                    var intersectRect = new Size((int)bounds.Width, (int)bounds.Height) - this.Size;
+                    if (SystemInterop.CurrentPlatform == PluginPlatform.Windows)
+                    {
+                        var offset = new Point((int)bounds.X, (int)bounds.Y);
+                        var intersectRect = new Size((int)bounds.Width, (int)bounds.Height) - this.Size;
 
-                    var x = Math.Min(Math.Max(0, this.Location.X), intersectRect.Width);
-                    var y = Math.Min(Math.Max(0, this.Location.Y), intersectRect.Height);
-                    this.Location = new Point(x, y) + offset;
+                        var x = Math.Min(Math.Max(0, this.Location.X), intersectRect.Width);
+                        var y = Math.Min(Math.Max(0, this.Location.Y), intersectRect.Height);
+                        this.Location = new Point(x, y) + offset;
+                    }
                 }
                 this.alreadyShown = true;
             }

--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -51,19 +51,16 @@ namespace OpenTabletDriver.UX
             base.OnShown(e);
 
             // Size and Location becomes available only during and after Shown event, LoadComplete don't have it yet
-            if (SystemInterop.CurrentPlatform == PluginPlatform.Windows)
+            if (SystemInterop.CurrentPlatform == PluginPlatform.Windows && !this.AlreadyShown)
             {
-                if (!this.AlreadyShown)
-                {
-                    var bounds = Screen.FromPoint(this.Location + new Point(this.Size.Width / 2, this.Size.Height / 2)).Bounds;
-                    var offset = new Point((int)bounds.X, (int)bounds.Y);
-                    var intersectRect = new Size((int)bounds.Width, (int)bounds.Height) - this.Size;
+                var bounds = Screen.FromPoint(this.Location + new Point(this.Size.Width / 2, this.Size.Height / 2)).Bounds;
+                var offset = new Point((int)bounds.X, (int)bounds.Y);
+                var intersectRect = new Size((int)bounds.Width, (int)bounds.Height) - this.Size;
 
-                    var x = Math.Min(Math.Max(0, this.Location.X), intersectRect.Width);
-                    var y = Math.Min(Math.Max(0, this.Location.Y), intersectRect.Height);
-                    this.Location = new Point(x, y) + offset;
-                    this.AlreadyShown = true;
-                }
+                var x = Math.Min(Math.Max(0, this.Location.X), intersectRect.Width);
+                var y = Math.Min(Math.Max(0, this.Location.Y), intersectRect.Height);
+                this.Location = new Point(x, y) + offset;
+                this.AlreadyShown = true;
             }
         }
 

--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -59,15 +59,12 @@ namespace OpenTabletDriver.UX
                     var minWidth = Math.Min(SystemInterop.CurrentPlatform == PluginPlatform.MacOS ? 970 : 960, bounds.Width * 0.9);
                     var minHeight = Math.Min(SystemInterop.CurrentPlatform == PluginPlatform.MacOS ? 770 : 760, bounds.Height * 0.9);
                     this.ClientSize = new Size((int)minWidth, (int)minHeight);
-                    if (SystemInterop.CurrentPlatform == PluginPlatform.Windows)
-                    {
-                        var offset = new Point((int)bounds.X, (int)bounds.Y);
-                        var intersectRect = new Size((int)bounds.Width, (int)bounds.Height) - this.Size;
+                    var offset = new Point((int)bounds.X, (int)bounds.Y);
+                    var intersectRect = new Size((int)bounds.Width, (int)bounds.Height) - this.Size;
 
-                        var x = Math.Min(Math.Max(0, this.Location.X), intersectRect.Width);
-                        var y = Math.Min(Math.Max(0, this.Location.Y), intersectRect.Height);
-                        this.Location = new Point(x, y) + offset;
-                    }
+                    var x = Math.Min(Math.Max(0, this.Location.X), intersectRect.Width);
+                    var y = Math.Min(Math.Max(0, this.Location.Y), intersectRect.Height);
+                    this.Location = new Point(x, y) + offset;
                 }
                 this.alreadyShown = true;
             }

--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -50,15 +50,25 @@ namespace OpenTabletDriver.UX
             base.OnShown(e);
 
             // Size and Location becomes available only during and after Shown event, LoadComplete don't have it yet
-            if (SystemInterop.CurrentPlatform == PluginPlatform.Windows && !this.alreadyShown)
+            if (!this.alreadyShown)
             {
                 var bounds = Screen.FromPoint(this.Location + new Point(this.Size.Width / 2, this.Size.Height / 2)).Bounds;
-                var offset = new Point((int)bounds.X, (int)bounds.Y);
-                var intersectRect = new Size((int)bounds.Width, (int)bounds.Height) - this.Size;
 
-                var x = Math.Min(Math.Max(0, this.Location.X), intersectRect.Width);
-                var y = Math.Min(Math.Max(0, this.Location.Y), intersectRect.Height);
-                this.Location = new Point(x, y) + offset;
+                if (this.WindowState == WindowState.Normal)
+                {
+                    var minWidth = Math.Min(SystemInterop.CurrentPlatform == PluginPlatform.MacOS ? 970 : 960, bounds.Width * 0.9);
+                    var minHeight = Math.Min(SystemInterop.CurrentPlatform == PluginPlatform.MacOS ? 770 : 760, bounds.Height * 0.9);
+                    this.ClientSize = new Size((int)minWidth, (int)minHeight);
+                    if (SystemInterop.CurrentPlatform == PluginPlatform.Windows)
+                    {
+                        var offset = new Point((int)bounds.X, (int)bounds.Y);
+                        var intersectRect = new Size((int)bounds.Width, (int)bounds.Height) - this.Size;
+
+                        var x = Math.Min(Math.Max(0, this.Location.X), intersectRect.Width);
+                        var y = Math.Min(Math.Max(0, this.Location.Y), intersectRect.Height);
+                        this.Location = new Point(x, y) + offset;
+                    }
+                }
                 this.alreadyShown = true;
             }
         }
@@ -295,10 +305,6 @@ namespace OpenTabletDriver.UX
                 PluginPlatform.MacOS => new Padding(10),
                 _                    => new Padding(0)
             };
-
-            var minWidth = Math.Min(SystemInterop.CurrentPlatform == PluginPlatform.MacOS ? 970 : 960, Screen.DisplayBounds.Width * 0.9);
-            var minHeight = Math.Min(SystemInterop.CurrentPlatform == PluginPlatform.MacOS ? 770 : 760, Screen.DisplayBounds.Height * 0.9);
-            this.ClientSize = new Size((int)minWidth, (int)minHeight);
 
             bool enableDaemonWatchdog = SystemInterop.CurrentPlatform switch
             {

--- a/OpenTabletDriver.UX/Windows/Greeter/StartupGreeterWindow.cs
+++ b/OpenTabletDriver.UX/Windows/Greeter/StartupGreeterWindow.cs
@@ -11,7 +11,10 @@ namespace OpenTabletDriver.UX.Windows.Greeter
         public StartupGreeterWindow()
         {
             base.Title = "OpenTabletDriver Guide";
-            base.ClientSize = new Size(895, 680);
+            var bounds = Application.Instance.MainForm.Screen.Bounds;
+            var minWidth = Math.Min(895, bounds.Width * 0.85);
+            var minHeight = Math.Min(680, bounds.Height * 0.85);
+            base.ClientSize = new Size((int)minWidth, (int)minHeight);
             base.Icon = App.Logo.WithSize(256, 256);
         }
 

--- a/OpenTabletDriver.UX/Windows/Greeter/StartupGreeterWindow.cs
+++ b/OpenTabletDriver.UX/Windows/Greeter/StartupGreeterWindow.cs
@@ -15,7 +15,8 @@ namespace OpenTabletDriver.UX.Windows.Greeter
             base.Icon = App.Logo.WithSize(256, 256);
         }
 
-        public StartupGreeterWindow(Window parent) : this()
+        public StartupGreeterWindow(Window parent)
+            : this()
         {
             base.Owner = parent;
         }

--- a/OpenTabletDriver.UX/Windows/Greeter/StartupGreeterWindow.cs
+++ b/OpenTabletDriver.UX/Windows/Greeter/StartupGreeterWindow.cs
@@ -15,16 +15,14 @@ namespace OpenTabletDriver.UX.Windows.Greeter
             base.Icon = App.Logo.WithSize(256, 256);
         }
 
+        public StartupGreeterWindow(Window parent) : this()
+        {
+            base.Owner = parent;
+        }
+
         protected override void OnLoadComplete(EventArgs e)
         {
             base.OnLoadComplete(e);
-
-            var bounds = Screen.FromPoint(this.Location + new Point(this.ClientSize.Width / 2, this.ClientSize.Height / 2)).Bounds;
-            var offset = new Point((int)bounds.X, (int)bounds.Y);
-
-            var x = (bounds.Width / 2) - (this.ClientSize.Width / 2);
-            var y = (Screen.DisplayBounds.Size.Height / 2) - (this.ClientSize.Height / 2);
-            this.Location = new Point((int)x, (int)y) + offset;
 
             var pageViewer = new StartupGreeterPageViewer
             {

--- a/OpenTabletDriver.UX/Windows/Greeter/StartupGreeterWindow.cs
+++ b/OpenTabletDriver.UX/Windows/Greeter/StartupGreeterWindow.cs
@@ -19,6 +19,13 @@ namespace OpenTabletDriver.UX.Windows.Greeter
         {
             base.OnLoadComplete(e);
 
+            var bounds = Screen.FromPoint(this.Location + new Point(this.ClientSize.Width / 2, this.ClientSize.Height / 2)).Bounds;
+            var offset = new Point((int)bounds.X, (int)bounds.Y);
+
+            var x = (bounds.Width / 2) - (this.ClientSize.Width / 2);
+            var y = (Screen.DisplayBounds.Size.Height / 2) - (this.ClientSize.Height / 2);
+            this.Location = new Point((int)x, (int)y) + offset;
+
             var pageViewer = new StartupGreeterPageViewer
             {
                 Pages =


### PR DESCRIPTION
# Changes

- OTD Window size at launch will either be the old defaults, or 90% of screen, whichever is smaller on that axis. Helps with 1366x768 monitors where main UX is always too big on launch.
- "Try" to make the whole of OTD window visible on the screen it got launched (Windows only)
- Set MainForm as parent of Greeter so Greeter will always be launched centered on supporting platforms.

Windows 10 somehow don't remember the last window position of OTD and always spawn it randomly; almost always in a way where OTD gets cut off on smaller screens (1366x768)

About the "Try" part, Eto seems to have a bug where there is an added offset to `Form.Location`, atleast on Windows.