### PR TITLE
Use latest plugin update and check driver compatibility

### DIFF
--- a/OpenTabletDriver.UX/Windows/PluginManagerWindow.cs
+++ b/OpenTabletDriver.UX/Windows/PluginManagerWindow.cs
@@ -216,6 +216,7 @@ namespace OpenTabletDriver.UX.Windows
             protected WeakReference<PluginMetadata> MetadataReference { set; get; } = new WeakReference<PluginMetadata>(null);
 
             private EmptyMetadataControl emptyMetadataControl = new EmptyMetadataControl();
+            private Version driverVersion = Assembly.GetExecutingAssembly().GetName().Version;
 
             public void Update(PluginMetadata metadata)
             {
@@ -239,12 +240,14 @@ namespace OpenTabletDriver.UX.Windows
                     Repository ??= await PluginMetadataCollection.DownloadAsync();
 
                     bool isInstalled = contexts.Any(t => PluginMetadata.Match(t.GetMetadata(), metadata));
-                    bool canUpdate = Repository.Any(t => t.Name == metadata.Name && t.PluginVersion > metadata.PluginVersion);
 
                     var updatableFromRepository = from meta in Repository
-                        where meta.PluginVersion > metadata.PluginVersion
-                        orderby meta.PluginVersion
+                        where meta.Name == metadata.Name && meta.PluginVersion > metadata.PluginVersion
+                        where driverVersion >= meta.SupportedDriverVersion
+                        orderby meta.PluginVersion descending
                         select meta;
+
+                    var canUpdate = updatableFromRepository.Any();
 
                     var actions = new StackLayout
                     {


### PR DESCRIPTION
## Changes

- Check if plugin metadata is compatible to current driver
- If there is more than on matching metadata, sort it in descending order so `updatableFromRepository.First()` returns the latest version of that plugin
- Merge LINQ query