### PR TITLE
Wrong dimensions for G640S

### DIFF
--- a/OpenTabletDriver/Configurations/XP-Pen/G640s.json
+++ b/OpenTabletDriver/Configurations/XP-Pen/G640s.json
@@ -2,8 +2,8 @@
   "Name": "XP-Pen G640s",
   "DigitizerIdentifiers": [
     {
-      "Width": 165.0,
-      "Height": 103.0,
+      "Width": 165.1,
+      "Height": 101.6,
       "MaxX": 32999.0,
       "MaxY": 20599.0,
       "MaxPressure": 8191,


### PR DESCRIPTION
https://www.xp-pen.com/product/54.html
The specs and the user manual say the active area is 6.5"*4", which is 165.1mm*101.6 instead of 165.0mm*103.0mm