### PR TITLE
Update MTE-450.json

### DIFF
--- a/OpenTabletDriver/Configurations/Wacom/MTE-450.json
+++ b/OpenTabletDriver/Configurations/Wacom/MTE-450.json
@@ -8,8 +8,8 @@
       "MaxY": 9225.0,
       "MaxPressure": 511,
       "ActiveReportID": {
-        "Start": null,
-        "StartInclusive": false,
+        "Start": 32,
+        "StartInclusive": true,
         "End": null,
         "EndInclusive": false
       },
@@ -30,8 +30,8 @@
       "MaxY": 9225.0,
       "MaxPressure": 511,
       "ActiveReportID": {
-        "Start": null,
-        "StartInclusive": false,
+        "Start": 32,
+        "StartInclusive": true,
         "End": null,
         "EndInclusive": false
       },


### PR DESCRIPTION
Update the Range, in which ReportIDs are valid with the MTE-450 Tablet, in order to fix #655 
Tablet ReportIDs (in hex):
x1= Pen Tip Touching tablet
x0 = Pen Tip not touching tablet
1x = Pen over Tablet
2x = dected eraser
4x = detected pen tip
8x = stable pen output / goes to 0, whenever pen is far away, but before a dissconnection from the pen