### PR TITLE
Fix bugs and add MaxPenButtonCount

### DIFF
--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -276,28 +276,37 @@ namespace OpenTabletDriver.Daemon
             BindingHandler.TipActivationPressure = Settings.TipActivationPressure;
             Log.Write("Settings", $"Tip Binding: [{BindingHandler.TipBinding}]@{BindingHandler.TipActivationPressure}%");
 
-            if (Settings.PenButtons != null)
+            if (Driver.Tablet is TabletState tablet)
             {
-                for (int index = 0; index < Settings.PenButtons.Count; index++)
+                if (Settings.PenButtons != null)
                 {
-                    var bind = Settings.PenButtons[index]?.Construct<IBinding>();
-                    if (!BindingHandler.PenButtonBindings.TryAdd(index, bind))
-                        BindingHandler.PenButtonBindings[index] = bind;
+                    var penCount = tablet.Digitizer?.MaxPenButtonCount ?? 0;
+                    for (int index = 0; index < penCount; index++)
+                    {
+                        if (Settings.PenButtons.Count <= index)
+                            Settings.PenButtons.Add(null);
+                        var bind = Settings.PenButtons[index]?.Construct<IBinding>();
+                        if (!BindingHandler.PenButtonBindings.TryAdd(index, bind))
+                            BindingHandler.PenButtonBindings[index] = bind;
+                    }
+
+                    Log.Write("Settings", $"Pen Bindings: " + string.Join(", ", BindingHandler.PenButtonBindings));
                 }
 
-                Log.Write("Settings", $"Pen Bindings: " + string.Join(", ", BindingHandler.PenButtonBindings));
-            }
-
-            if (Settings.AuxButtons != null)
-            {
-                for (int index = 0; index < Settings.AuxButtons.Count; index++)
+                if (Settings.AuxButtons != null)
                 {
-                    var bind = Settings.AuxButtons[index]?.Construct<IBinding>();
-                    if (!BindingHandler.AuxButtonBindings.TryAdd(index, bind))
-                        BindingHandler.AuxButtonBindings[index] = bind;
-                }
+                    var auxCount = tablet.Auxiliary?.ButtonCount ?? tablet.Digitizer?.ButtonCount ?? 0;
+                    for (int index = 0; index < auxCount; index++)
+                    {
+                        if (Settings.AuxButtons.Count <= index)
+                            Settings.AuxButtons.Add(null);
+                        var bind = Settings.AuxButtons[index]?.Construct<IBinding>();
+                        if (!BindingHandler.AuxButtonBindings.TryAdd(index, bind))
+                            BindingHandler.AuxButtonBindings[index] = bind;
+                    }
 
-                Log.Write("Settings", $"Express Key Bindings: " + string.Join(", ", BindingHandler.AuxButtonBindings));
+                    Log.Write("Settings", $"Express Key Bindings: " + string.Join(", ", BindingHandler.AuxButtonBindings));
+                }
             }
         }
 

--- a/OpenTabletDriver.Desktop/Migration/SettingsMigrator.cs
+++ b/OpenTabletDriver.Desktop/Migration/SettingsMigrator.cs
@@ -11,18 +11,14 @@ namespace OpenTabletDriver.Desktop.Migration
         {
             // Output mode
             MigrateNamespace(settings.OutputMode);
-            
+
             // Bindings
             if (settings.TipButton is PluginSettingStore tipStore)
                 MigrateNamespace(tipStore);
 
-            while(settings.PenButtons.Count < Settings.PenButtonCount)
-                settings.PenButtons.Add(null);
             foreach (PluginSettingStore store in settings.PenButtons)
                 MigrateNamespace(store);
 
-            while (settings.AuxButtons.Count < Settings.AuxButtonCount)
-                settings.AuxButtons.Add(null);
             foreach (PluginSettingStore store in settings.AuxButtons)
                 MigrateNamespace(store);
 

--- a/OpenTabletDriver.Desktop/Settings.cs
+++ b/OpenTabletDriver.Desktop/Settings.cs
@@ -15,9 +15,6 @@ namespace OpenTabletDriver.Desktop
         {
         }
 
-        internal const int PenButtonCount = 2;
-        internal const int AuxButtonCount = 6;
-
         private float _dW, _dH, _dX, _dY, _tW, _tH, _tX, _tY, _r, _xS, _yS, _relRot, _tP;
         private TimeSpan _rT;
         private bool _lockar, _sizeChanging, _autoHook, _clipping, _areaLimiting, _lockUsableAreaDisplay, _lockUsableAreaTablet;

--- a/OpenTabletDriver.Plugin/Tablet/DigitizerIdentifier.cs
+++ b/OpenTabletDriver.Plugin/Tablet/DigitizerIdentifier.cs
@@ -28,6 +28,11 @@
         public uint MaxPressure { set; get; }
 
         /// <summary>
+        /// The tablet's maximum supported pen button count, excluding eraser.
+        /// </summary>
+        public uint MaxPenButtonCount { set; get; }
+
+        /// <summary>
         /// The tablet's active detection report ID.
         /// </summary>
         public DetectionRange ActiveReportID { set; get; }

--- a/OpenTabletDriver.UX/Controls/BindingEditor.cs
+++ b/OpenTabletDriver.UX/Controls/BindingEditor.cs
@@ -1,7 +1,7 @@
 using System;
-using Eto.Drawing;
 using Eto.Forms;
 using OpenTabletDriver.Desktop.Reflection;
+using OpenTabletDriver.Plugin.Tablet;
 using OpenTabletDriver.UX.Controls.Generic;
 using OpenTabletDriver.UX.Windows.Bindings;
 
@@ -22,11 +22,11 @@ namespace OpenTabletDriver.UX.Controls
 
         private StackView content = new StackView();
 
-        public async void UpdateBindings()
+        public async void UpdateBindings(TabletState tablet = null)
         {
             content.Items.Clear();
 
-            var tablet = await App.Driver.Instance.GetTablet();
+            tablet ??= await App.Driver.Instance.GetTablet();
 
             var tipButton = new BindingDisplay(App.Settings?.TipButton)
             {
@@ -52,8 +52,10 @@ namespace OpenTabletDriver.UX.Controls
             var tipSettings = new Group("Tip Bindings", tipSettingsStack);
 
             var penBindingsStack = new StackView();
-            for (int i = 0; i < (tablet?.Digitizer.ButtonCount ?? 0); i++)
+            for (int i = 0; i < (tablet?.Digitizer?.MaxPenButtonCount ?? 0); i++)
             {
+                if (App.Settings?.PenButtons?.Count <= i)
+                    App.Settings?.PenButtons?.Add(null);
                 var penBinding = new BindingDisplay(App.Settings?.PenButtons[i])
                 {
                     Width = 250,
@@ -83,8 +85,11 @@ namespace OpenTabletDriver.UX.Controls
             content.AddControl(penSettings);
 
             var auxBindingsStack = new StackView();
-            for (int i = 0; i < (tablet?.Auxiliary.ButtonCount ?? 0); i++)
+            var auxCount = tablet?.Auxiliary?.ButtonCount ?? tablet?.Digitizer?.ButtonCount ?? 0;
+            for (int i = 0; i < auxCount; i++)
             {
+                if (App.Settings?.AuxButtons?.Count <= i)
+                    App.Settings?.AuxButtons?.Add(null);
                 var auxBinding = new BindingDisplay(App.Settings?.AuxButtons[i])
                 {
                     Width = 250,

--- a/OpenTabletDriver.UX/Controls/OutputModeEditor.cs
+++ b/OpenTabletDriver.UX/Controls/OutputModeEditor.cs
@@ -20,15 +20,6 @@ namespace OpenTabletDriver.UX.Controls
     {
         public OutputModeEditor()
         {
-            UpdateOutputMode(App.Settings?.OutputMode);
-            App.SettingsChanged += (settings) => UpdateOutputMode(settings?.OutputMode);
-
-            outputModeSelector.SelectedValueChanged += (sender, args) =>
-            {
-                App.Settings.OutputMode = new PluginSettingStore(outputModeSelector.SelectedType);
-                UpdateOutputMode(App.Settings.OutputMode);
-            };
-
             this.Content = outputPanel = new StackLayout
             {
                 Padding = 5,
@@ -41,6 +32,15 @@ namespace OpenTabletDriver.UX.Controls
                     new StackLayoutItem(noModeEditor, true),
                     new StackLayoutItem(outputModeSelector, HorizontalAlignment.Left, false)
                 }
+            };
+
+            UpdateOutputMode(App.Settings?.OutputMode);
+            App.SettingsChanged += (settings) => UpdateOutputMode(settings?.OutputMode);
+
+            outputModeSelector.SelectedValueChanged += (sender, args) =>
+            {
+                App.Settings.OutputMode = new PluginSettingStore(outputModeSelector.SelectedType);
+                UpdateOutputMode(App.Settings.OutputMode);
             };
         }
 
@@ -140,6 +140,7 @@ namespace OpenTabletDriver.UX.Controls
         {
             public OutputModeSelector()
             {
+                UpdateSelectedMode(App.Settings?.OutputMode);
                 App.SettingsChanged += (settings) => UpdateSelectedMode(settings?.OutputMode);
             }
 
@@ -209,6 +210,7 @@ namespace OpenTabletDriver.UX.Controls
                         );
                     }
 
+                    Rebind(App.Settings);
                     App.SettingsChanged += Rebind;
                 }
 
@@ -252,6 +254,7 @@ namespace OpenTabletDriver.UX.Controls
 
                     AppendMenuItem("Convert area...", async () => await ConvertAreaDialog());
 
+                    Rebind(App.Settings);
                     App.SettingsChanged += Rebind;
                 }
 

--- a/OpenTabletDriver.UX/Windows/Configurations/Controls/DigitizerIdentifierEntry.cs
+++ b/OpenTabletDriver.UX/Windows/Configurations/Controls/DigitizerIdentifierEntry.cs
@@ -43,6 +43,10 @@ namespace OpenTabletDriver.UX.Windows.Configurations.Controls
                 () => GetCurrent().MaxPressure.ToString(),
                 (o) => ModifyCurrent(id => id.MaxPressure = ToUInt(o))
             );
+            yield return new InputBox("Max Pen Button Count",
+                () => GetCurrent().MaxPenButtonCount.ToString(),
+                (o) => ModifyCurrent(id => id.MaxPenButtonCount = ToUInt(o))
+            );
             yield return new InputBox("Active Report ID",
                 () => GetCurrent().ActiveReportID?.ToString() ?? new DetectionRange().ToString(),
                 (o) => ModifyCurrent(id => id.ActiveReportID = DetectionRange.Parse(o))

--- a/OpenTabletDriver/Configurations/Gaomon/1060 Pro.json
+++ b/OpenTabletDriver/Configurations/Gaomon/1060 Pro.json
@@ -7,6 +7,7 @@
       "MaxX": 50800.0,
       "MaxY": 31750.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": true,

--- a/OpenTabletDriver/Configurations/Gaomon/M106K.json
+++ b/OpenTabletDriver/Configurations/Gaomon/M106K.json
@@ -7,6 +7,7 @@
       "MaxX": 40000.0,
       "MaxY": 25000.0,
       "MaxPressure": 2047,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": true,

--- a/OpenTabletDriver/Configurations/Gaomon/S56K.json
+++ b/OpenTabletDriver/Configurations/Gaomon/S56K.json
@@ -7,6 +7,7 @@
       "MaxX": 32000.0,
       "MaxY": 24000.0,
       "MaxPressure": 2047,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": true,

--- a/OpenTabletDriver/Configurations/Gaomon/S620.json
+++ b/OpenTabletDriver/Configurations/Gaomon/S620.json
@@ -7,6 +7,7 @@
       "MaxX": 33020.0,
       "MaxY": 20320.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": true,

--- a/OpenTabletDriver/Configurations/Huion/GT-133.json
+++ b/OpenTabletDriver/Configurations/Huion/GT-133.json
@@ -7,6 +7,7 @@
       "MaxX": 58752.0,
       "MaxY": 33048.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": true,
@@ -25,7 +26,7 @@
         "201": "HUION_M182_\\d{6}$"
       },
       "InitializationStrings": [
-        "200"
+        200
       ]
     }
   ],

--- a/OpenTabletDriver/Configurations/Huion/H1060P.json
+++ b/OpenTabletDriver/Configurations/Huion/H1060P.json
@@ -7,6 +7,7 @@
       "MaxX": 50800.0,
       "MaxY": 31750.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": true,

--- a/OpenTabletDriver/Configurations/Huion/H430P.json
+++ b/OpenTabletDriver/Configurations/Huion/H430P.json
@@ -7,6 +7,7 @@
       "MaxX": 24384.0,
       "MaxY": 15240.0,
       "MaxPressure": 4095,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": true,
@@ -34,6 +35,7 @@
       "MaxX": 24384.0,
       "MaxY": 15240.0,
       "MaxPressure": 4095,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": true,

--- a/OpenTabletDriver/Configurations/Huion/H610 Pro V2.json
+++ b/OpenTabletDriver/Configurations/Huion/H610 Pro V2.json
@@ -7,6 +7,7 @@
       "MaxX": 50800.0,
       "MaxY": 31750.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": true,
@@ -25,7 +26,7 @@
         "201": "HUION_T184_\\d{6}$"
       },
       "InitializationStrings": [
-        "200"
+        200
       ]
     }
   ],

--- a/OpenTabletDriver/Configurations/Huion/H610 Pro.json
+++ b/OpenTabletDriver/Configurations/Huion/H610 Pro.json
@@ -7,6 +7,7 @@
       "MaxX": 50800.0,
       "MaxY": 31750.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": true,
@@ -25,7 +26,7 @@
         "201": "HUION_T175_\\d{6}$"
       },
       "InitializationStrings": [
-        "200"
+        200
       ]
     },
     {
@@ -34,6 +35,7 @@
       "MaxX": 50800.0,
       "MaxY": 31750.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": true,
@@ -52,7 +54,7 @@
         "201": "HUION_T175_\\d{6}$"
       },
       "InitializationStrings": [
-        "200"
+        200
       ]
     }
   ],

--- a/OpenTabletDriver/Configurations/Huion/H640P.json
+++ b/OpenTabletDriver/Configurations/Huion/H640P.json
@@ -7,6 +7,7 @@
       "MaxX": 32000.0,
       "MaxY": 20000.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": true,
@@ -34,6 +35,7 @@
       "MaxX": 32000.0,
       "MaxY": 20000.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": true,

--- a/OpenTabletDriver/Configurations/Huion/HS610.json
+++ b/OpenTabletDriver/Configurations/Huion/HS610.json
@@ -7,6 +7,7 @@
       "MaxX": 50800.0,
       "MaxY": 31750.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": true,

--- a/OpenTabletDriver/Configurations/Huion/HS611.json
+++ b/OpenTabletDriver/Configurations/Huion/HS611.json
@@ -7,6 +7,7 @@
       "MaxX": 51680.0,
       "MaxY": 32300.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": true,

--- a/OpenTabletDriver/Configurations/Huion/HS64.json
+++ b/OpenTabletDriver/Configurations/Huion/HS64.json
@@ -7,6 +7,7 @@
       "MaxX": 32000.0,
       "MaxY": 20400.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": true,

--- a/OpenTabletDriver/Configurations/Huion/Inspiroy Q11K V2.json
+++ b/OpenTabletDriver/Configurations/Huion/Inspiroy Q11K V2.json
@@ -7,6 +7,7 @@
       "MaxX": 55880.0,
       "MaxY": 34925.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": true,

--- a/OpenTabletDriver/Configurations/Huion/Inspiroy Q11K.json
+++ b/OpenTabletDriver/Configurations/Huion/Inspiroy Q11K.json
@@ -7,6 +7,7 @@
       "MaxX": 51680.0,
       "MaxY": 33020.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": true,

--- a/OpenTabletDriver/Configurations/Huion/New 1060 Plus.json
+++ b/OpenTabletDriver/Configurations/Huion/New 1060 Plus.json
@@ -7,6 +7,7 @@
       "MaxX": 50800.0,
       "MaxY": 31750.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 128,
         "StartInclusive": true,
@@ -28,12 +29,13 @@
         200
       ]
     },
-	  {
+    {
       "Width": 254.0,
       "Height": 158.75,
       "MaxX": 50800.0,
       "MaxY": 31750.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": true,

--- a/OpenTabletDriver/Configurations/Huion/Q620M.json
+++ b/OpenTabletDriver/Configurations/Huion/Q620M.json
@@ -7,6 +7,7 @@
       "MaxX": 53340.0,
       "MaxY": 33020.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": true,

--- a/OpenTabletDriver/Configurations/Huion/osu!tablet.json
+++ b/OpenTabletDriver/Configurations/Huion/osu!tablet.json
@@ -7,6 +7,7 @@
       "MaxX": 8340.0,
       "MaxY": 4680.0,
       "MaxPressure": 2047,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 128,
         "StartInclusive": false,

--- a/OpenTabletDriver/Configurations/VEIKK/A15 Pro.json
+++ b/OpenTabletDriver/Configurations/VEIKK/A15 Pro.json
@@ -7,6 +7,7 @@
       "MaxX": 50800.0,
       "MaxY": 30480.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": false,

--- a/OpenTabletDriver/Configurations/VEIKK/A15.json
+++ b/OpenTabletDriver/Configurations/VEIKK/A15.json
@@ -7,6 +7,7 @@
       "MaxX": 50800.0,
       "MaxY": 30480.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": false,

--- a/OpenTabletDriver/Configurations/VEIKK/A30.json
+++ b/OpenTabletDriver/Configurations/VEIKK/A30.json
@@ -7,6 +7,7 @@
       "MaxX": 50800.0,
       "MaxY": 30480.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": false,

--- a/OpenTabletDriver/Configurations/VEIKK/A50.json
+++ b/OpenTabletDriver/Configurations/VEIKK/A50.json
@@ -7,6 +7,7 @@
       "MaxX": 50800.0,
       "MaxY": 30480.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": false,

--- a/OpenTabletDriver/Configurations/VEIKK/S640.json
+++ b/OpenTabletDriver/Configurations/VEIKK/S640.json
@@ -7,6 +7,7 @@
       "MaxX": 30480.0,
       "MaxY": 20320.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 80,
         "StartInclusive": true,

--- a/OpenTabletDriver/Configurations/Wacom/CTE-430.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTE-430.json
@@ -7,6 +7,7 @@
       "MaxX": 10208.0,
       "MaxY": 7424.0,
       "MaxPressure": 511,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 0,
         "StartInclusive": false,
@@ -30,6 +31,7 @@
       "MaxX": 10208.0,
       "MaxY": 7424.0,
       "MaxPressure": 511,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 0,
         "StartInclusive": false,

--- a/OpenTabletDriver/Configurations/Wacom/CTE-440.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTE-440.json
@@ -7,6 +7,7 @@
       "MaxX": 10208.0,
       "MaxY": 7424.0,
       "MaxPressure": 511,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 0,
         "StartInclusive": false,
@@ -30,6 +31,7 @@
       "MaxX": 10208.0,
       "MaxY": 7424.0,
       "MaxPressure": 511,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 0,
         "StartInclusive": false,

--- a/OpenTabletDriver/Configurations/Wacom/CTE-460.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTE-460.json
@@ -7,6 +7,7 @@
       "MaxX": 15200.0,
       "MaxY": 9500.0,
       "MaxPressure": 511,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 0,
         "StartInclusive": false,
@@ -30,6 +31,7 @@
       "MaxX": 15200.0,
       "MaxY": 9500.0,
       "MaxPressure": 511,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 0,
         "StartInclusive": false,

--- a/OpenTabletDriver/Configurations/Wacom/CTE-650.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTE-650.json
@@ -7,6 +7,7 @@
       "MaxX": 21648.0,
       "MaxY": 13530.0,
       "MaxPressure": 511,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 0,
         "StartInclusive": false,

--- a/OpenTabletDriver/Configurations/Wacom/CTH-460.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTH-460.json
@@ -7,6 +7,7 @@
       "MaxX": 14720.0,
       "MaxY": 9200.0,
       "MaxPressure": 1023,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": false,
@@ -30,6 +31,7 @@
       "MaxX": 14720.0,
       "MaxY": 9200.0,
       "MaxPressure": 1023,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": false,

--- a/OpenTabletDriver/Configurations/Wacom/CTH-470.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTH-470.json
@@ -7,6 +7,7 @@
       "MaxX": 14720.0,
       "MaxY": 9200.0,
       "MaxPressure": 1023,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": false,
@@ -30,6 +31,7 @@
       "MaxX": 14720.0,
       "MaxY": 9200.0,
       "MaxPressure": 1023,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": false,

--- a/OpenTabletDriver/Configurations/Wacom/CTH-480.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTH-480.json
@@ -7,6 +7,7 @@
       "MaxX": 15200.0,
       "MaxY": 9500.0,
       "MaxPressure": 1023,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": false,
@@ -30,6 +31,7 @@
       "MaxX": 15200.0,
       "MaxY": 9500.0,
       "MaxPressure": 1023,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": false,

--- a/OpenTabletDriver/Configurations/Wacom/CTH-490.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTH-490.json
@@ -7,6 +7,7 @@
       "MaxX": 15200.0,
       "MaxY": 9500.0,
       "MaxPressure": 2047,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 0,
         "StartInclusive": false,
@@ -30,6 +31,7 @@
       "MaxX": 15200.0,
       "MaxY": 9500.0,
       "MaxPressure": 2047,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 0,
         "StartInclusive": false,

--- a/OpenTabletDriver/Configurations/Wacom/CTH-670.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTH-670.json
@@ -7,6 +7,7 @@
       "MaxX": 21648.0,
       "MaxY": 13700.0,
       "MaxPressure": 1023,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": false,
@@ -30,6 +31,7 @@
       "MaxX": 21648.0,
       "MaxY": 13700.0,
       "MaxPressure": 1023,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": false,

--- a/OpenTabletDriver/Configurations/Wacom/CTH-680.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTH-680.json
@@ -7,6 +7,7 @@
       "MaxX": 21600.0,
       "MaxY": 13500.0,
       "MaxPressure": 1023,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": false,
@@ -30,6 +31,7 @@
       "MaxX": 21600.0,
       "MaxY": 13500.0,
       "MaxPressure": 1023,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": false,

--- a/OpenTabletDriver/Configurations/Wacom/CTH-690.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTH-690.json
@@ -7,6 +7,7 @@
       "MaxX": 21600.0,
       "MaxY": 13500.0,
       "MaxPressure": 2047,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 16,
         "StartInclusive": false,
@@ -30,6 +31,7 @@
       "MaxX": 21600.0,
       "MaxY": 13500.0,
       "MaxPressure": 2047,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 16,
         "StartInclusive": false,

--- a/OpenTabletDriver/Configurations/Wacom/CTL-4100 Bluetooth.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTL-4100 Bluetooth.json
@@ -7,6 +7,7 @@
       "MaxX": 15200.0,
       "MaxY": 9500.0,
       "MaxPressure": 4095,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 16,
         "StartInclusive": true,
@@ -30,6 +31,7 @@
       "MaxX": 15200.0,
       "MaxY": 9500.0,
       "MaxPressure": 4095,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 16,
         "StartInclusive": true,

--- a/OpenTabletDriver/Configurations/Wacom/CTL-4100.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTL-4100.json
@@ -7,6 +7,7 @@
       "MaxX": 15200.0,
       "MaxY": 9500.0,
       "MaxPressure": 4095,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 16,
         "StartInclusive": true,
@@ -30,6 +31,7 @@
       "MaxX": 15200.0,
       "MaxY": 9500.0,
       "MaxPressure": 4095,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 16,
         "StartInclusive": true,

--- a/OpenTabletDriver/Configurations/Wacom/CTL-4100WL.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTL-4100WL.json
@@ -7,6 +7,7 @@
       "MaxX": 15200.0,
       "MaxY": 9500.0,
       "MaxPressure": 4095,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 16,
         "StartInclusive": true,
@@ -30,6 +31,7 @@
       "MaxX": 15200.0,
       "MaxY": 9500.0,
       "MaxPressure": 4095,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 16,
         "StartInclusive": true,

--- a/OpenTabletDriver/Configurations/Wacom/CTL-460.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTL-460.json
@@ -7,6 +7,7 @@
       "MaxX": 14720.0,
       "MaxY": 9200.0,
       "MaxPressure": 1023,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": false,
@@ -30,6 +31,7 @@
       "MaxX": 14720.0,
       "MaxY": 9200.0,
       "MaxPressure": 1023,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": false,

--- a/OpenTabletDriver/Configurations/Wacom/CTL-470.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTL-470.json
@@ -7,6 +7,7 @@
       "MaxX": 14720.0,
       "MaxY": 9200.0,
       "MaxPressure": 1023,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": false,
@@ -30,6 +31,7 @@
       "MaxX": 14720.0,
       "MaxY": 9200.0,
       "MaxPressure": 1023,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": false,

--- a/OpenTabletDriver/Configurations/Wacom/CTL-471.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTL-471.json
@@ -7,6 +7,7 @@
       "MaxX": 15200.0,
       "MaxY": 9500.0,
       "MaxPressure": 1023,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": false,
@@ -30,6 +31,7 @@
       "MaxX": 15200.0,
       "MaxY": 9500.0,
       "MaxPressure": 1023,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": false,

--- a/OpenTabletDriver/Configurations/Wacom/CTL-472.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTL-472.json
@@ -7,6 +7,7 @@
       "MaxX": 15200.0,
       "MaxY": 9500.0,
       "MaxPressure": 2047,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": false,
@@ -30,6 +31,7 @@
       "MaxX": 15200.0,
       "MaxY": 9500.0,
       "MaxPressure": 2047,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": false,

--- a/OpenTabletDriver/Configurations/Wacom/CTL-480.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTL-480.json
@@ -7,6 +7,7 @@
       "MaxX": 15200.0,
       "MaxY": 9500.0,
       "MaxPressure": 1023,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": false,
@@ -30,6 +31,7 @@
       "MaxX": 15200.0,
       "MaxY": 9500.0,
       "MaxPressure": 1023,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": false,

--- a/OpenTabletDriver/Configurations/Wacom/CTL-490.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTL-490.json
@@ -7,6 +7,7 @@
       "MaxX": 15200.0,
       "MaxY": 9500.0,
       "MaxPressure": 2047,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 0,
         "StartInclusive": false,
@@ -30,6 +31,7 @@
       "MaxX": 15200.0,
       "MaxY": 9500.0,
       "MaxPressure": 2047,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 0,
         "StartInclusive": false,

--- a/OpenTabletDriver/Configurations/Wacom/CTL-6100.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTL-6100.json
@@ -7,6 +7,7 @@
       "MaxX": 21600.0,
       "MaxY": 13500.0,
       "MaxPressure": 4095,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": null,
         "StartInclusive": false,

--- a/OpenTabletDriver/Configurations/Wacom/CTL-671.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTL-671.json
@@ -7,6 +7,7 @@
       "MaxX": 21648.0,
       "MaxY": 15330.0,
       "MaxPressure": 1023,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": false,
@@ -30,6 +31,7 @@
       "MaxX": 21648.0,
       "MaxY": 15330.0,
       "MaxPressure": 1023,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": false,

--- a/OpenTabletDriver/Configurations/Wacom/CTL-672.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTL-672.json
@@ -7,6 +7,7 @@
       "MaxX": 21600.0,
       "MaxY": 13500.0,
       "MaxPressure": 2047,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": false,
@@ -30,6 +31,7 @@
       "MaxX": 21600.0,
       "MaxY": 13500.0,
       "MaxPressure": 2047,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": false,

--- a/OpenTabletDriver/Configurations/Wacom/CTL-680.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTL-680.json
@@ -7,6 +7,7 @@
       "MaxX": 21600.0,
       "MaxY": 13500.0,
       "MaxPressure": 1023,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": false,
@@ -30,6 +31,7 @@
       "MaxX": 21600.0,
       "MaxY": 13500.0,
       "MaxPressure": 1023,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": false,

--- a/OpenTabletDriver/Configurations/Wacom/CTL-690.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTL-690.json
@@ -7,6 +7,7 @@
       "MaxX": 21600.0,
       "MaxY": 13500.0,
       "MaxPressure": 2047,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 16,
         "StartInclusive": false,
@@ -30,6 +31,7 @@
       "MaxX": 21600.0,
       "MaxY": 13500.0,
       "MaxPressure": 2047,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 16,
         "StartInclusive": false,

--- a/OpenTabletDriver/Configurations/Wacom/FT-0405-U.json
+++ b/OpenTabletDriver/Configurations/Wacom/FT-0405-U.json
@@ -7,6 +7,7 @@
       "MaxX": 5104.0,
       "MaxY": 3712.0,
       "MaxPressure": 511,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 72,
         "StartInclusive": true,
@@ -30,6 +31,7 @@
       "MaxX": 5104.0,
       "MaxY": 3712.0,
       "MaxPressure": 511,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 72,
         "StartInclusive": false,

--- a/OpenTabletDriver/Configurations/Wacom/MTE-450.json
+++ b/OpenTabletDriver/Configurations/Wacom/MTE-450.json
@@ -7,6 +7,7 @@
       "MaxX": 14760.0,
       "MaxY": 9225.0,
       "MaxPressure": 511,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": false,
@@ -30,6 +31,7 @@
       "MaxX": 14760.0,
       "MaxY": 9225.0,
       "MaxPressure": 511,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 64,
         "StartInclusive": false,

--- a/OpenTabletDriver/Configurations/Wacom/PTH-451.json
+++ b/OpenTabletDriver/Configurations/Wacom/PTH-451.json
@@ -7,6 +7,7 @@
       "MaxX": 31496.0,
       "MaxY": 19685.0,
       "MaxPressure": 2047,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 0,
         "StartInclusive": false,
@@ -30,6 +31,7 @@
       "MaxX": 31496.0,
       "MaxY": 19685.0,
       "MaxPressure": 2047,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 0,
         "StartInclusive": false,

--- a/OpenTabletDriver/Configurations/Wacom/PTH-651.json
+++ b/OpenTabletDriver/Configurations/Wacom/PTH-651.json
@@ -7,6 +7,7 @@
       "MaxX": 44704.0,
       "MaxY": 27940.0,
       "MaxPressure": 2047,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 0,
         "StartInclusive": false,
@@ -30,6 +31,7 @@
       "MaxX": 44704.0,
       "MaxY": 27940.0,
       "MaxPressure": 2047,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 0,
         "StartInclusive": false,

--- a/OpenTabletDriver/Configurations/Wacom/PTH-660 Bluetooth.json
+++ b/OpenTabletDriver/Configurations/Wacom/PTH-660 Bluetooth.json
@@ -7,6 +7,7 @@
       "MaxX": 44800.0,
       "MaxY": 29600.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 0,
         "StartInclusive": false,
@@ -30,6 +31,7 @@
       "MaxX": 44800.0,
       "MaxY": 29600.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 0,
         "StartInclusive": false,

--- a/OpenTabletDriver/Configurations/Wacom/PTH-660.json
+++ b/OpenTabletDriver/Configurations/Wacom/PTH-660.json
@@ -7,6 +7,7 @@
       "MaxX": 44800.0,
       "MaxY": 29600.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 16,
         "StartInclusive": true,
@@ -30,6 +31,7 @@
       "MaxX": 44800.0,
       "MaxY": 29600.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 16,
         "StartInclusive": true,

--- a/OpenTabletDriver/Configurations/Wacom/PTH-850.json
+++ b/OpenTabletDriver/Configurations/Wacom/PTH-850.json
@@ -7,6 +7,7 @@
       "MaxX": 65024.0,
       "MaxY": 40640.0,
       "MaxPressure": 2047,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 1,
         "StartInclusive": false,
@@ -30,6 +31,7 @@
       "MaxX": 65024.0,
       "MaxY": 40640.0,
       "MaxPressure": 2047,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 1,
         "StartInclusive": false,

--- a/OpenTabletDriver/Configurations/Wacom/PTH-860.json
+++ b/OpenTabletDriver/Configurations/Wacom/PTH-860.json
@@ -7,6 +7,7 @@
       "MaxX": 62200.0,
       "MaxY": 43200.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 16,
         "StartInclusive": true,
@@ -30,6 +31,7 @@
       "MaxX": 62200.0,
       "MaxY": 43200.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 16,
         "StartInclusive": true,

--- a/OpenTabletDriver/Configurations/Wacom/PTK-1240.json
+++ b/OpenTabletDriver/Configurations/Wacom/PTK-1240.json
@@ -7,6 +7,7 @@
       "MaxX": 97536.0,
       "MaxY": 60960.0,
       "MaxPressure": 2047,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 1,
         "StartInclusive": false,
@@ -30,6 +31,7 @@
       "MaxX": 97536.0,
       "MaxY": 60960.0,
       "MaxPressure": 2047,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 1,
         "StartInclusive": false,

--- a/OpenTabletDriver/Configurations/Wacom/PTK-440.json
+++ b/OpenTabletDriver/Configurations/Wacom/PTK-440.json
@@ -2,11 +2,12 @@
   "Name": "Wacom PTK-440",
   "DigitizerIdentifiers": [
     {
-      "Width": 157.480,
+      "Width": 157.48,
       "Height": 98.425,
       "MaxX": 31496.0,
       "MaxY": 19685.0,
       "MaxPressure": 2047,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 0,
         "StartInclusive": true,
@@ -25,11 +26,12 @@
       "InitializationStrings": []
     },
     {
-      "Width": 157.480,
+      "Width": 157.48,
       "Height": 98.425,
       "MaxX": 31496.0,
       "MaxY": 19685.0,
       "MaxPressure": 2047,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 0,
         "StartInclusive": true,

--- a/OpenTabletDriver/Configurations/Wacom/PTK-540WL.json
+++ b/OpenTabletDriver/Configurations/Wacom/PTK-540WL.json
@@ -7,6 +7,7 @@
       "MaxX": 40640.0,
       "MaxY": 25400.0,
       "MaxPressure": 2047,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 0,
         "StartInclusive": false,
@@ -30,6 +31,7 @@
       "MaxX": 40640.0,
       "MaxY": 25400.0,
       "MaxPressure": 2047,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 0,
         "StartInclusive": false,

--- a/OpenTabletDriver/Configurations/XP-Pen/Deco 01 v2.json
+++ b/OpenTabletDriver/Configurations/XP-Pen/Deco 01 v2.json
@@ -7,6 +7,7 @@
       "MaxX": 25400.0,
       "MaxY": 15875.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 80,
         "StartInclusive": true,
@@ -30,6 +31,7 @@
       "MaxX": 25400.0,
       "MaxY": 15875.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 80,
         "StartInclusive": true,

--- a/OpenTabletDriver/Configurations/XP-Pen/Deco 01.json
+++ b/OpenTabletDriver/Configurations/XP-Pen/Deco 01.json
@@ -7,6 +7,7 @@
       "MaxX": 25400.0,
       "MaxY": 15875.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 128,
         "StartInclusive": false,

--- a/OpenTabletDriver/Configurations/XP-Pen/Deco 02.json
+++ b/OpenTabletDriver/Configurations/XP-Pen/Deco 02.json
@@ -5,8 +5,9 @@
       "Width": 223.52,
       "Height": 139.7,
       "MaxX": 22352.0,
-      "MaxY": 13970,
+      "MaxY": 13970.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 80,
         "StartInclusive": true,

--- a/OpenTabletDriver/Configurations/XP-Pen/Deco 03.json
+++ b/OpenTabletDriver/Configurations/XP-Pen/Deco 03.json
@@ -7,6 +7,7 @@
       "MaxX": 50800.0,
       "MaxY": 28575.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 80,
         "StartInclusive": true,

--- a/OpenTabletDriver/Configurations/XP-Pen/G430.json
+++ b/OpenTabletDriver/Configurations/XP-Pen/G430.json
@@ -7,6 +7,7 @@
       "MaxX": 45720.0,
       "MaxY": 29210.0,
       "MaxPressure": 2047,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 80,
         "StartInclusive": true,
@@ -32,6 +33,7 @@
       "MaxX": 20320.0,
       "MaxY": 15240.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 80,
         "StartInclusive": true,

--- a/OpenTabletDriver/Configurations/XP-Pen/G430S.json
+++ b/OpenTabletDriver/Configurations/XP-Pen/G430S.json
@@ -7,6 +7,7 @@
       "MaxX": 10160.0,
       "MaxY": 7620.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 80,
         "StartInclusive": true,

--- a/OpenTabletDriver/Configurations/XP-Pen/G540 Pro.json
+++ b/OpenTabletDriver/Configurations/XP-Pen/G540 Pro.json
@@ -7,6 +7,7 @@
       "MaxX": 54720.0,
       "MaxY": 29210.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 80,
         "StartInclusive": true,

--- a/OpenTabletDriver/Configurations/XP-Pen/G540.json
+++ b/OpenTabletDriver/Configurations/XP-Pen/G540.json
@@ -7,6 +7,7 @@
       "MaxX": 45720.0,
       "MaxY": 29210.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 80,
         "StartInclusive": true,

--- a/OpenTabletDriver/Configurations/XP-Pen/G640 v2.json
+++ b/OpenTabletDriver/Configurations/XP-Pen/G640 v2.json
@@ -7,6 +7,7 @@
       "MaxX": 15999.0,
       "MaxY": 9999.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 80,
         "StartInclusive": true,

--- a/OpenTabletDriver/Configurations/XP-Pen/G640.json
+++ b/OpenTabletDriver/Configurations/XP-Pen/G640.json
@@ -7,6 +7,7 @@
       "MaxX": 32000.0,
       "MaxY": 20000.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 80,
         "StartInclusive": true,

--- a/OpenTabletDriver/Configurations/XP-Pen/G640s.json
+++ b/OpenTabletDriver/Configurations/XP-Pen/G640s.json
@@ -7,6 +7,7 @@
       "MaxX": 32999.0,
       "MaxY": 20599.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 80,
         "StartInclusive": true,
@@ -24,12 +25,13 @@
       "DeviceStrings": {},
       "InitializationStrings": []
     },
-	{
+    {
       "Width": 165.0,
       "Height": 103.0,
       "MaxX": 32999.0,
       "MaxY": 20599.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 80,
         "StartInclusive": true,

--- a/OpenTabletDriver/Configurations/XP-Pen/G960.json
+++ b/OpenTabletDriver/Configurations/XP-Pen/G960.json
@@ -7,6 +7,7 @@
       "MaxX": 22352.0,
       "MaxY": 13970.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 80,
         "StartInclusive": true,

--- a/OpenTabletDriver/Configurations/XP-Pen/Star 03.json
+++ b/OpenTabletDriver/Configurations/XP-Pen/Star 03.json
@@ -7,6 +7,7 @@
       "MaxX": 50800.0,
       "MaxY": 30480.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 80,
         "StartInclusive": true,
@@ -30,6 +31,7 @@
       "MaxX": 50800.0,
       "MaxY": 30480.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 80,
         "StartInclusive": true,

--- a/OpenTabletDriver/Configurations/XP-Pen/Star 06.json
+++ b/OpenTabletDriver/Configurations/XP-Pen/Star 06.json
@@ -7,6 +7,7 @@
       "MaxX": 50800.0,
       "MaxY": 30480.0,
       "MaxPressure": 8191,
+      "MaxPenButtonCount": 2,
       "ActiveReportID": {
         "Start": 80,
         "StartInclusive": true,

--- a/OpenTabletDriver/Driver.cs
+++ b/OpenTabletDriver/Driver.cs
@@ -47,11 +47,13 @@ namespace OpenTabletDriver
         {
             private set
             {
+                if (value != Tablet)
+                    TabletChanged?.Invoke(this, value);
+
                 // Stored locally to avoid re-detecting to switch output modes
                 this.tablet = value;
                 if (OutputMode != null)
                     OutputMode.Tablet = Tablet;
-                TabletChanged?.Invoke(this, Tablet);
             }
             get => this.tablet;
         }


### PR DESCRIPTION
- [x] Add `MaxPenButtonCount` to tablet configurations

## Notes

`Driver.TabletChanged` was previously spamming nulls which locked UX on `bindingEditor.UpdateBindings()`, so this PR resolves that by triggering the event only when the `Driver.Tablet` actually changed. There were also some `STAThread` exceptions not found before.