### PR TITLE
Fix race conditions of interpolators

### DIFF
--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -141,6 +141,10 @@ namespace OpenTabletDriver.Daemon
 
         public Task SetSettings(Settings settings)
         {
+            foreach (var interpolator in Driver.Interpolators)
+                interpolator.Dispose();
+            Driver.Interpolators.Clear();
+
             Settings = SettingsMigrator.Migrate(settings);
 
             var pluginRef = Settings.OutputMode?.GetPluginReference() ?? AppInfo.PluginManager.GetPluginReference(typeof(AbsoluteMode));
@@ -323,10 +327,6 @@ namespace OpenTabletDriver.Daemon
 
         private void SetInterpolatorSettings()
         {
-            foreach (var interpolator in Driver.Interpolators)
-                interpolator.Dispose();
-            Driver.Interpolators.Clear();
-
             foreach (PluginSettingStore store in Settings.Interpolators)
             {
                 if (store.Enable == false)
@@ -341,6 +341,7 @@ namespace OpenTabletDriver.Daemon
                         select filter;
 
                     interpolator.Filters = filters.ToList();
+                    interpolator.Enabled = true;
                     Driver.Interpolators.Add(interpolator);
                     Log.Write("Settings", $"Interpolator: {interpolator}");
                 }

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -141,6 +141,7 @@ namespace OpenTabletDriver.Daemon
 
         public Task SetSettings(Settings settings)
         {
+            // Dispose all interpolators to begin changing settings
             foreach (var interpolator in Driver.Interpolators)
                 interpolator.Dispose();
             Driver.Interpolators.Clear();

--- a/OpenTabletDriver.Desktop/Interop/Timer/FallbackTimer.cs
+++ b/OpenTabletDriver.Desktop/Interop/Timer/FallbackTimer.cs
@@ -82,7 +82,7 @@ namespace OpenTabletDriver.Desktop.Interop.Timer
                     continue;
                 }
 
-                Elapsed();
+                Elapsed?.Invoke();
             }
 
             stopWatch.Stop();

--- a/OpenTabletDriver.Native/Windows/Timers/EventType.cs
+++ b/OpenTabletDriver.Native/Windows/Timers/EventType.cs
@@ -5,7 +5,8 @@ namespace OpenTabletDriver.Native.Windows.Timers
     [Flags]
     public enum EventType : uint
     {
-        TIME_ONESHOT = 0,      //Event occurs once, after uDelay milliseconds.
-        TIME_PERIODIC = 1,
+        TIME_ONESHOT = 0,      // Event occurs once, after uDelay milliseconds.
+        TIME_PERIODIC = 1,     // Event occurs every after uDelay milliseconds.
+        TIME_KILL_SYNCHRONOUS = 0x100     // Immediately stop timer when requested.
     }
 }


### PR DESCRIPTION
## Changes

- Safe invoke `Elapsed`
- Dispose interpolators before performing changes on the input processing pipeline
- Ensure that timers/schedulers' `Start()` and `Stop()` are not redundantly called
- Fix race condition on `Interpolator.Dispose()`
- Fix `Interpolator.InRange` and `Interpolator.Enabled`. Do only as the variable states.
- Synchronously kill Windows timer

## Test

Before PR: Crash when applying settings with pen while an interpolator is active
After PR: Did not crash after spamming apply