### PR TITLE
Invoke TabletChanged only when it actually changed

### DIFF
--- a/OpenTabletDriver/Driver.cs
+++ b/OpenTabletDriver/Driver.cs
@@ -47,11 +47,13 @@ namespace OpenTabletDriver
         {
             private set
             {
+                if (value != this.tablet)
+                    TabletChanged?.Invoke(this, value);
+
                 // Stored locally to avoid re-detecting to switch output modes
                 this.tablet = value;
                 if (OutputMode != null)
                     OutputMode.Tablet = Tablet;
-                TabletChanged?.Invoke(this, Tablet);
             }
             get => this.tablet;
         }

--- a/OpenTabletDriver/Driver.cs
+++ b/OpenTabletDriver/Driver.cs
@@ -48,12 +48,13 @@ namespace OpenTabletDriver
             private set
             {
                 if (value != this.tablet)
+                {
+                    // Stored locally to avoid re-detecting to switch output modes
+                    this.tablet = value;
+                    if (OutputMode != null)
+                        OutputMode.Tablet = Tablet;
                     TabletChanged?.Invoke(this, value);
-
-                // Stored locally to avoid re-detecting to switch output modes
-                this.tablet = value;
-                if (OutputMode != null)
-                    OutputMode.Tablet = Tablet;
+                }
             }
             get => this.tablet;
         }


### PR DESCRIPTION
## Test

### Procedure

Replug tablet

### Before PR

`TabletChanged` is invoked once on disconnect, and then invoked for every configuration until a match is found.

### After PR

`TabletChanged` is invoked only once on both disconnect and reconnect.