### PR TITLE
Remove the unnecessary refresh on launch

### DIFF
--- a/OpenTabletDriver.UX/Controls/OutputModeEditor.cs
+++ b/OpenTabletDriver.UX/Controls/OutputModeEditor.cs
@@ -20,15 +20,6 @@ namespace OpenTabletDriver.UX.Controls
     {
         public OutputModeEditor()
         {
-            UpdateOutputMode(App.Settings?.OutputMode);
-            App.SettingsChanged += (settings) => UpdateOutputMode(settings?.OutputMode);
-
-            outputModeSelector.SelectedValueChanged += (sender, args) =>
-            {
-                App.Settings.OutputMode = new PluginSettingStore(outputModeSelector.SelectedType);
-                UpdateOutputMode(App.Settings.OutputMode);
-            };
-
             this.Content = outputPanel = new StackLayout
             {
                 Padding = 5,
@@ -41,6 +32,15 @@ namespace OpenTabletDriver.UX.Controls
                     new StackLayoutItem(noModeEditor, true),
                     new StackLayoutItem(outputModeSelector, HorizontalAlignment.Left, false)
                 }
+            };
+
+            UpdateOutputMode(App.Settings?.OutputMode);
+            App.SettingsChanged += (settings) => UpdateOutputMode(settings?.OutputMode);
+
+            outputModeSelector.SelectedValueChanged += (sender, args) =>
+            {
+                App.Settings.OutputMode = new PluginSettingStore(outputModeSelector.SelectedType);
+                UpdateOutputMode(App.Settings.OutputMode);
             };
         }
 
@@ -140,6 +140,7 @@ namespace OpenTabletDriver.UX.Controls
         {
             public OutputModeSelector()
             {
+                UpdateSelectedMode(App.Settings?.OutputMode);
                 App.SettingsChanged += (settings) => UpdateSelectedMode(settings?.OutputMode);
             }
 
@@ -209,6 +210,7 @@ namespace OpenTabletDriver.UX.Controls
                         );
                     }
 
+                    Rebind(App.Settings);
                     App.SettingsChanged += Rebind;
                 }
 
@@ -252,6 +254,7 @@ namespace OpenTabletDriver.UX.Controls
 
                     AppendMenuItem("Convert area...", async () => await ConvertAreaDialog());
 
+                    Rebind(App.Settings);
                     App.SettingsChanged += Rebind;
                 }
 

--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -43,6 +43,7 @@ namespace OpenTabletDriver.UX
             InitializeAsync();
         }
 
+        private FileInfo settingsFile;
         private OutputModeEditor outputModeEditor;
         private BindingEditor bindingEditor;
         private PluginSettingStoreCollectionEditor<IFilter> filterEditor;
@@ -385,13 +386,16 @@ namespace OpenTabletDriver.UX
             if (await Driver.Instance.GetTablet() is TabletState tablet)
                 outputModeEditor.SetTabletSize(tablet);
 
+            if (!settingsFile.Exists && this.WindowState != WindowState.Minimized)
+                await ShowFirstStartupGreeter();
+
             Driver.Instance.TabletChanged += (sender, tablet) => outputModeEditor.SetTabletSize(tablet);
         }
 
         private async Task LoadSettings(AppInfo appInfo = null)
         {
             appInfo ??= await Driver.Instance.GetApplicationInfo();
-            var settingsFile = new FileInfo(appInfo.SettingsFile);
+            settingsFile = new FileInfo(appInfo.SettingsFile);
             if (await Driver.Instance.GetSettings() is Settings settings)
             {
                 Settings = settings;
@@ -413,9 +417,6 @@ namespace OpenTabletDriver.UX
             {
                 await ResetSettings();
             }
-
-            if (!settingsFile.Exists && this.WindowState != WindowState.Minimized)
-                await ShowFirstStartupGreeter();
         }
 
         private async Task ResetSettings(bool force = true)

--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -244,6 +244,8 @@ namespace OpenTabletDriver.UX
                 }
             };
 
+            outputModeEditor.SetDisplaySize(SystemInterop.VirtualScreen.Displays);
+
             return new StackLayout
             {
                 Items =
@@ -376,14 +378,14 @@ namespace OpenTabletDriver.UX
 
             Log.Output += async (sender, message) => await Driver.Instance.WriteMessage(message);
 
+            await LoadSettings(AppInfo.Current);
+
             Content = ConstructMainControls();
 
             if (await Driver.Instance.GetTablet() is TabletState tablet)
                 outputModeEditor.SetTabletSize(tablet);
 
             Driver.Instance.TabletChanged += (sender, tablet) => outputModeEditor.SetTabletSize(tablet);
-
-            await LoadSettings(AppInfo.Current);
         }
 
         private async Task LoadSettings(AppInfo appInfo = null)
@@ -414,8 +416,6 @@ namespace OpenTabletDriver.UX
 
             if (!settingsFile.Exists)
                 await ShowFirstStartupGreeter();
-
-            outputModeEditor.SetDisplaySize(SystemInterop.VirtualScreen.Displays);
         }
 
         private async Task ResetSettings(bool force = true)

--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -407,13 +407,13 @@ namespace OpenTabletDriver.UX
             settingsFile = new FileInfo(appInfo.SettingsFile);
             if (await Driver.Instance.GetSettings() is Settings settings)
             {
-                Application.Instance.AsyncInvoke(() => Settings = settings);
+                await Application.Instance.InvokeAsync(() => Settings = settings);
             }
             else if (settingsFile.Exists)
             {
                 try
                 {
-                    Application.Instance.AsyncInvoke(() => Settings = Settings.Deserialize(settingsFile));
+                    await Application.Instance.InvokeAsync(() => Settings = Settings.Deserialize(settingsFile));
                     await Driver.Instance.SetSettings(Settings);
                 }
                 catch

--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -414,7 +414,7 @@ namespace OpenTabletDriver.UX
                 await ResetSettings();
             }
 
-            if (!settingsFile.Exists)
+            if (!settingsFile.Exists && this.WindowState != WindowState.Minimized)
                 await ShowFirstStartupGreeter();
         }
 


### PR DESCRIPTION
## Test

**Procedure**

Launch `OTD.UX`

---

**Before PR**

The UX loads up the controls, loads the settings, and then refreshes the output mode.

**After PR**

The UX loads the settings, and then loads the controls.