### PR TITLE
Fix STAThread exception

### DIFF
--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -392,13 +392,13 @@ namespace OpenTabletDriver.UX
             var settingsFile = new FileInfo(appInfo.SettingsFile);
             if (await Driver.Instance.GetSettings() is Settings settings)
             {
-                Settings = settings;
+                Application.Instance.AsyncInvoke(() => Settings = settings);
             }
             else if (settingsFile.Exists)
             {
                 try
                 {
-                    Settings = Settings.Deserialize(settingsFile);
+                    Application.Instance.AsyncInvoke(() => Settings = Settings.Deserialize(settingsFile));
                     await Driver.Instance.SetSettings(Settings);
                 }
                 catch


### PR DESCRIPTION
## Test (Windows)

**Procedure**

Replug tablet

---

**Before PR**

STAThread exception while applying the new settings from `SettingsChanged` event

**After PR**

No more STAThread exception