### PR TITLE
Fix minimize behaviour with taskbar

### DIFF
--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -87,6 +87,8 @@ namespace OpenTabletDriver.UX
             if (App.EnableTrayIcon)
             {
                 var trayIcon = new TrayIcon(this);
+                if (WindowState == WindowState.Minimized)
+                    this.ShowInTaskbar = false;
                 this.WindowStateChanged += (sender, e) =>
                 {
                     switch (this.WindowState)
@@ -97,7 +99,6 @@ namespace OpenTabletDriver.UX
                             break;
                         case WindowState.Minimized:
                             this.ShowInTaskbar = false;
-                            this.Visible = false;
                             break;
                     }
                 };

--- a/OpenTabletDriver.UX/TrayIcon.cs
+++ b/OpenTabletDriver.UX/TrayIcon.cs
@@ -14,9 +14,7 @@ namespace OpenTabletDriver.UX
             showWindow.Click += (sender, e) =>
             {
                 window.Show();
-                window.WindowState = WindowState.Normal;
                 window.BringToFront();
-                window.WindowStyle = WindowStyle.Default;
             };
 
             var close = new ButtonMenuItem
@@ -41,9 +39,7 @@ namespace OpenTabletDriver.UX
 			indicator.Activated += (object sender, System.EventArgs e) =>
             {
                 window.Show();
-                window.WindowState = WindowState.Normal;
                 window.BringToFront();
-                window.WindowStyle = WindowStyle.Default;
             };
             indicator.Show();
         }


### PR DESCRIPTION
and remove unnecessary changes to `Window*`.

## Test (Windows)

Launch OTD minimized

**Before PR**

OTD icon is shown on taskbar

**After PR**

OTD icon is hidden on taskbar