### PR TITLE
Fix font related crashes on MacOS

### DIFF
--- a/OpenTabletDriver.UX/Controls/Generic/Group.cs
+++ b/OpenTabletDriver.UX/Controls/Generic/Group.cs
@@ -118,7 +118,7 @@ namespace OpenTabletDriver.UX.Controls.Generic
                                 Control = new Label
                                 {
                                     Text = this.Text,
-                                    Font = Fonts.Sans(9, FontStyle.Bold)
+                                    Font = SystemFonts.Bold(9)
                                 }
                             },
                             new StackLayoutItem

--- a/OpenTabletDriver.UX/Controls/Generic/Group.cs
+++ b/OpenTabletDriver.UX/Controls/Generic/Group.cs
@@ -118,7 +118,7 @@ namespace OpenTabletDriver.UX.Controls.Generic
                                 Control = new Label
                                 {
                                     Text = this.Text,
-                                    Font = Fonts.Cached("Sans", 9, FontStyle.Bold)
+                                    Font = Fonts.Sans(9, FontStyle.Bold)
                                 }
                             },
                             new StackLayoutItem

--- a/OpenTabletDriver.UX/Windows/Greeter/Pages/AreaEditorPage.cs
+++ b/OpenTabletDriver.UX/Windows/Greeter/Pages/AreaEditorPage.cs
@@ -23,7 +23,7 @@ namespace OpenTabletDriver.UX.Windows.Greeter.Pages
                         Content = new DemoAreaEditor("mm", true)
                     }
                 },
-                new StylizedText("This is the area editor.", Fonts.Cached("Sans", 9, FontStyle.Bold), new Padding(0, 0, 0, 4)),
+                new StylizedText("This is the area editor.", Fonts.Sans(9, FontStyle.Bold), new Padding(0, 0, 0, 4)),
                 "You can right click the absolute output mode area editor for more options.",
                 "Aligning, resizing, and flipping your area can be done within this context menu.",
                 "Other options such as locking aspect ratio, locking input inside of the usable area are also found here.",

--- a/OpenTabletDriver.UX/Windows/Greeter/Pages/AreaEditorPage.cs
+++ b/OpenTabletDriver.UX/Windows/Greeter/Pages/AreaEditorPage.cs
@@ -23,7 +23,7 @@ namespace OpenTabletDriver.UX.Windows.Greeter.Pages
                         Content = new DemoAreaEditor("mm", true)
                     }
                 },
-                new StylizedText("This is the area editor.", Fonts.Sans(9, FontStyle.Bold), new Padding(0, 0, 0, 4)),
+                new StylizedText("This is the area editor.", SystemFonts.Bold(9), new Padding(0, 0, 0, 4)),
                 "You can right click the absolute output mode area editor for more options.",
                 "Aligning, resizing, and flipping your area can be done within this context menu.",
                 "Other options such as locking aspect ratio, locking input inside of the usable area are also found here.",

--- a/OpenTabletDriver.UX/Windows/Greeter/Pages/BindingPage.cs
+++ b/OpenTabletDriver.UX/Windows/Greeter/Pages/BindingPage.cs
@@ -52,7 +52,7 @@ namespace OpenTabletDriver.UX.Windows.Greeter.Pages
                         }
                     }
                 },
-                new StylizedText("This is the binding editor.", Fonts.Sans(9, FontStyle.Bold), new Padding(0, 0, 0, 4)),
+                new StylizedText("This is the binding editor.", SystemFonts.Bold(9), new Padding(0, 0, 0, 4)),
                 "It allows you to set specific actions that OTD will perform when, for example, a tablet button is pressed.",
                 "Click on the left button to capture a mouse or keyboard binding.",
                 "Click on the right button to open the advanced binding editor, which allows you to use plugin bindings.",

--- a/OpenTabletDriver.UX/Windows/Greeter/Pages/BindingPage.cs
+++ b/OpenTabletDriver.UX/Windows/Greeter/Pages/BindingPage.cs
@@ -52,7 +52,7 @@ namespace OpenTabletDriver.UX.Windows.Greeter.Pages
                         }
                     }
                 },
-                new StylizedText("This is the binding editor.", Fonts.Cached("Sans", 9, FontStyle.Bold), new Padding(0, 0, 0, 4)),
+                new StylizedText("This is the binding editor.", Fonts.Sans(9, FontStyle.Bold), new Padding(0, 0, 0, 4)),
                 "It allows you to set specific actions that OTD will perform when, for example, a tablet button is pressed.",
                 "Click on the left button to capture a mouse or keyboard binding.",
                 "Click on the right button to open the advanced binding editor, which allows you to use plugin bindings.",

--- a/OpenTabletDriver.UX/Windows/Greeter/Pages/FAQPage.cs
+++ b/OpenTabletDriver.UX/Windows/Greeter/Pages/FAQPage.cs
@@ -13,7 +13,7 @@ namespace OpenTabletDriver.UX.Windows.Greeter.Pages
             {
                 new PaddingSpacerItem(),
                 new Bitmap(App.Logo.WithSize(150, 150)),
-                new StylizedText("FAQ", Fonts.Sans(12, FontStyle.Bold), new Padding(0, 0, 0, 8)),
+                new StylizedText("FAQ", SystemFonts.Bold(12), new Padding(0, 0, 0, 8)),
                 "If you have any issues, check out the FAQ.",
                 "This can be found under the Help menu in the main window.",
                 new PaddingSpacerItem(),

--- a/OpenTabletDriver.UX/Windows/Greeter/Pages/FAQPage.cs
+++ b/OpenTabletDriver.UX/Windows/Greeter/Pages/FAQPage.cs
@@ -1,5 +1,4 @@
 using Eto.Drawing;
-using OpenTabletDriver.Desktop.Interop;
 using OpenTabletDriver.UX.Attributes;
 using OpenTabletDriver.UX.Controls.Generic;
 
@@ -14,7 +13,7 @@ namespace OpenTabletDriver.UX.Windows.Greeter.Pages
             {
                 new PaddingSpacerItem(),
                 new Bitmap(App.Logo.WithSize(150, 150)),
-                new StylizedText("FAQ", Fonts.Cached("Sans", 12, FontStyle.Bold), new Padding(0, 0, 0, 8)),
+                new StylizedText("FAQ", Fonts.Sans(12, FontStyle.Bold), new Padding(0, 0, 0, 8)),
                 "If you have any issues, check out the FAQ.",
                 "This can be found under the Help menu in the main window.",
                 new PaddingSpacerItem(),

--- a/OpenTabletDriver.UX/Windows/Greeter/Pages/PluginPage.cs
+++ b/OpenTabletDriver.UX/Windows/Greeter/Pages/PluginPage.cs
@@ -13,7 +13,7 @@ namespace OpenTabletDriver.UX.Windows.Greeter.Pages
             {
                 new PaddingSpacerItem(),
                 new Bitmap(App.Logo.WithSize(150, 150)),
-                new StylizedText("Plugins", Fonts.Cached("Sans", 12, FontStyle.Bold), new Padding(0, 0, 0, 8)),
+                new StylizedText("Plugins", Fonts.Sans(12, FontStyle.Bold), new Padding(0, 0, 0, 8)),
                 "Plugins can be downloaded from the plugin manager at your own risk.",
                 "The plugin manager can be found in the Plugins menu in the main window.",
                 new PaddingSpacerItem()

--- a/OpenTabletDriver.UX/Windows/Greeter/Pages/PluginPage.cs
+++ b/OpenTabletDriver.UX/Windows/Greeter/Pages/PluginPage.cs
@@ -13,7 +13,7 @@ namespace OpenTabletDriver.UX.Windows.Greeter.Pages
             {
                 new PaddingSpacerItem(),
                 new Bitmap(App.Logo.WithSize(150, 150)),
-                new StylizedText("Plugins", Fonts.Sans(12, FontStyle.Bold), new Padding(0, 0, 0, 8)),
+                new StylizedText("Plugins", SystemFonts.Bold(12), new Padding(0, 0, 0, 8)),
                 "Plugins can be downloaded from the plugin manager at your own risk.",
                 "The plugin manager can be found in the Plugins menu in the main window.",
                 new PaddingSpacerItem()

--- a/OpenTabletDriver.UX/Windows/Greeter/Pages/WelcomePage.cs
+++ b/OpenTabletDriver.UX/Windows/Greeter/Pages/WelcomePage.cs
@@ -13,7 +13,7 @@ namespace OpenTabletDriver.UX.Windows.Greeter.Pages
             {
                 new PaddingSpacerItem(),
                 new Bitmap(App.Logo.WithSize(256, 256)),
-                new StylizedText("OpenTabletDriver Guide", Fonts.Sans(12, FontStyle.Bold), new Padding(0, 0, 0, 10)),
+                new StylizedText("OpenTabletDriver Guide", SystemFonts.Bold(12), new Padding(0, 0, 0, 10)),
                 "Welcome to OpenTabletDriver!",
                 "OpenTabletDriver is an open source, cross platform, user mode tablet driver.",
                 new PaddingSpacerItem(),

--- a/OpenTabletDriver.UX/Windows/Greeter/Pages/WelcomePage.cs
+++ b/OpenTabletDriver.UX/Windows/Greeter/Pages/WelcomePage.cs
@@ -1,5 +1,4 @@
 using Eto.Drawing;
-using Eto.Forms;
 using OpenTabletDriver.UX.Attributes;
 using OpenTabletDriver.UX.Controls.Generic;
 
@@ -14,7 +13,7 @@ namespace OpenTabletDriver.UX.Windows.Greeter.Pages
             {
                 new PaddingSpacerItem(),
                 new Bitmap(App.Logo.WithSize(256, 256)),
-                new StylizedText("OpenTabletDriver Guide", Fonts.Cached("Sans", 12, FontStyle.Bold), new Padding(0, 0, 0, 10)),
+                new StylizedText("OpenTabletDriver Guide", Fonts.Sans(12, FontStyle.Bold), new Padding(0, 0, 0, 10)),
                 "Welcome to OpenTabletDriver!",
                 "OpenTabletDriver is an open source, cross platform, user mode tablet driver.",
                 new PaddingSpacerItem(),


### PR DESCRIPTION
# Changes
- Switched all cases of `Font.Cached("Sans")` with `Font.Sans()`, which will use the cached Sans font as we intended to.

# Issues
- Closes #690 