### PR TITLE
Add Huion G10T configuration

### DIFF
--- a/OpenTabletDriver/Configurations/Huion/G10T.json
+++ b/OpenTabletDriver/Configurations/Huion/G10T.json
@@ -1,0 +1,35 @@
+{
+  "Name": "Huion G10T",
+  "DigitizerIdentifiers": [
+    {
+      "Width": 254.0,
+      "Height": 158.75,
+      "MaxX": 50800.0,
+      "MaxY": 31750.0,
+      "MaxPressure": 8191,
+      "ActiveReportID": {
+        "Start": 64,
+        "StartInclusive": true,
+        "End": null,
+        "EndInclusive": false
+      },
+      "VendorID": 9580,
+      "ProductID": 110,
+      "InputReportLength": 12,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Tablet.TabletReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": null,
+      "DeviceStrings": {
+		"201": "HUION_T161_\\d{6}$"
+	  },
+      "InitializationStrings": [
+		"200"
+	  ]
+    }
+  ],
+  "AuxilaryDeviceIdentifiers": [],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}


### PR DESCRIPTION
## Verification

#541 (Partially user verified, only tablet and sensor dimensions are not)

Tablet dimensions verification: [Huion official device page](https://www.huion.com/pen_tablet/InspiroyTouch/G10T.html)

`254mmx158.8mm` listed on the website is near the known `254mmx158.75mm`

## Issues

Closes #541