### PR TITLE
Hide window from task switchers when minimized

### DIFF
--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -89,16 +89,21 @@ namespace OpenTabletDriver.UX
             {
                 var trayIcon = new TrayIcon(this);
                 if (WindowState == WindowState.Minimized)
+                {
+                    this.Visible = false;
                     this.ShowInTaskbar = false;
+                }
                 this.WindowStateChanged += (sender, e) =>
                 {
                     switch (this.WindowState)
                     {
                         case WindowState.Normal:
                         case WindowState.Maximized:
+                            this.Visible = true;
                             this.ShowInTaskbar = true;
                             break;
                         case WindowState.Minimized:
+                            this.Visible = false;
                             this.ShowInTaskbar = false;
                             break;
                     }


### PR DESCRIPTION
Eto have undocumented effects of `Window.Visible`.

Closes #709