### PR TITLE
Fix STAThread exception on SetTabletSize

### DIFF
--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -398,8 +398,11 @@ namespace OpenTabletDriver.UX
             if (!settingsFile.Exists && this.WindowState != WindowState.Minimized)
                 await ShowFirstStartupGreeter();
 
-            Driver.Instance.TabletChanged += (sender, tablet) => outputModeEditor.SetTabletSize(tablet);
-            Driver.Instance.TabletChanged += (sender, tablet) => Application.Instance.AsyncInvoke(() => UpdateTitle(tablet));
+            Driver.Instance.TabletChanged += (sender, tablet) => Application.Instance.AsyncInvoke(() =>
+            {
+                outputModeEditor.SetTabletSize(tablet);
+                UpdateTitle(tablet);
+            });
         }
 
         public void UpdateTitle(TabletState tablet)


### PR DESCRIPTION
## Test

**Reproduction Steps** (Windows)

- Start OTD without plugging tablet.
- Plug the tablet after OTD starts up.

**Pre-PR**

Tablet Area editor shows "Invalid area size"

**Post-PR**

Tablet Area editor shows the tablet's size and user-set area as expected