### PR TITLE
Workaround output mode selector's layout bug

### DIFF
--- a/OpenTabletDriver.UX/Controls/OutputModeEditor.cs
+++ b/OpenTabletDriver.UX/Controls/OutputModeEditor.cs
@@ -30,7 +30,10 @@ namespace OpenTabletDriver.UX.Controls
                     new StackLayoutItem(absoluteModeEditor, true),
                     new StackLayoutItem(relativeModeEditor, true),
                     new StackLayoutItem(noModeEditor, true),
-                    new StackLayoutItem(outputModeSelector, HorizontalAlignment.Left, false)
+                    new StackLayout(outputModeSelector)
+                    {
+                        Size = new Size(300, -1)
+                    }
                 }
             };
 


### PR DESCRIPTION
## Test

**Reproduction** (Windows)

- Launch OTD

**Pre-PR**

![image](https://user-images.githubusercontent.com/10338031/105980276-9b019100-60cf-11eb-93ce-615061ddd265.png)

**Post-PR**

![image](https://user-images.githubusercontent.com/10338031/105980136-73122d80-60cf-11eb-98fb-bdda12f1df1d.png)
