### PR TITLE
Construct filters after preparing OutputMode

### DIFF
--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -154,14 +154,14 @@ namespace OpenTabletDriver.Daemon
             if (Driver.OutputMode != null)
                 Log.Write("Settings", $"Output mode: {pluginRef.Name ?? pluginRef.Path}");
 
-            if (Driver.OutputMode is IOutputMode outputMode)
-                SetOutputModeSettings(outputMode);
-
             if (Driver.OutputMode is AbsoluteOutputMode absoluteMode)
                 SetAbsoluteModeSettings(absoluteMode);
 
             if (Driver.OutputMode is RelativeOutputMode relativeMode)
                 SetRelativeModeSettings(relativeMode);
+
+            if (Driver.OutputMode is IOutputMode outputMode)
+                SetOutputModeSettings(outputMode);
 
             SetBindingHandlerSettings();
 
@@ -216,6 +216,8 @@ namespace OpenTabletDriver.Daemon
 
         private void SetOutputModeSettings(IOutputMode outputMode)
         {
+            outputMode.Tablet = Driver.Tablet;
+
             var filters = from store in Settings.Filters
                 where store.Enable == true
                 let filter = store.Construct<IFilter>()
@@ -225,8 +227,6 @@ namespace OpenTabletDriver.Daemon
 
             if (outputMode.Filters != null && outputMode.Filters.Count() > 0)
                 Log.Write("Settings", $"Filters: {string.Join(", ", outputMode.Filters)}");
-
-            outputMode.Tablet = Driver.Tablet;
         }
 
         private void SetAbsoluteModeSettings(AbsoluteOutputMode absoluteMode)


### PR DESCRIPTION
This allows for filters to cache certain variables like `Area` in their `ctor`.