### PR TITLE
Dispose filters that implement IDisposable interface

### DIFF
--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -162,10 +162,10 @@ namespace OpenTabletDriver.Daemon
             {
                 foreach (var filter in Driver.OutputMode.Filters)
                 {
-                    if (filter is not IDisposable disposableFilter) continue;
                     try
                     {
-                        disposableFilter.Dispose();
+                        if (filter is IDisposable disposableFilter)
+                            disposableFilter.Dispose();
                     }
                     catch(Exception)
                     {

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -156,6 +156,7 @@ namespace OpenTabletDriver.Daemon
             // Dispose all interpolators to begin changing settings
             foreach (var interpolator in Driver.Interpolators)
                 interpolator.Dispose();
+            Driver.Interpolators.Clear();
             
             // Dispose filters that implement IDisposable interface
             if (Driver.OutputMode?.Filters != null)
@@ -173,8 +174,6 @@ namespace OpenTabletDriver.Daemon
                     }
                 }
             }
-
-            Driver.Interpolators.Clear();
 
             Settings = SettingsMigrator.Migrate(settings);
 

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -156,6 +156,24 @@ namespace OpenTabletDriver.Daemon
             // Dispose all interpolators to begin changing settings
             foreach (var interpolator in Driver.Interpolators)
                 interpolator.Dispose();
+            
+            // Dispose filters that implement IDisposable interface
+            if (Driver.OutputMode?.Filters != null)
+            {
+                foreach (var filter in Driver.OutputMode.Filters)
+                {
+                    if (filter is not IDisposable disposableFilter) continue;
+                    try
+                    {
+                        disposableFilter.Dispose();
+                    }
+                    catch(Exception)
+                    {
+                        Log.Write("Plugin", $"Unable to dispose object '{filter.GetType().Name}'", LogLevel.Error);
+                    }
+                }
+            }
+
             Driver.Interpolators.Clear();
 
             Settings = SettingsMigrator.Migrate(settings);


### PR DESCRIPTION
This solves memory leak issues when filter has disposable fields and implements IDisposable interface.