### PR TITLE
Add XD-0608-U Configuration

### DIFF
--- a/OpenTabletDriver/Configurations/Wacom/XD-0608-U.json
+++ b/OpenTabletDriver/Configurations/Wacom/XD-0608-U.json
@@ -1,0 +1,50 @@
+{
+  "Name": "Wacom XD-0608-U",
+  "DigitizerIdentifiers": [
+    {
+      "Width": 203.2,
+      "Height": 162.4,
+      "MaxX": 40640.0,
+      "MaxY": 32480.0,
+      "MaxPressure": 1023,
+      "ActiveReportID": {
+        "Start": 0,
+        "StartInclusive": false,
+        "End": null,
+        "EndInclusive": false
+      },
+      "VendorID": 1386,
+      "ProductID": 66,
+      "InputReportLength": 10,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
+      "FeatureInitReport": "AgI=",
+      "OutputInitReport": null,
+      "DeviceStrings": {},
+      "InitializationStrings": []
+    },
+    {
+      "Width": 203.2,
+      "Height": 162.4,
+      "MaxX": 40640.0,
+      "MaxY": 32480.0,
+      "MaxPressure": 1023,
+      "ActiveReportID": {
+        "Start": 0,
+        "StartInclusive": false,
+        "End": null,
+        "EndInclusive": false
+      },
+      "VendorID": 1386,
+      "ProductID": 66,
+      "InputReportLength": 11,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
+      "FeatureInitReport": "AgI=",
+      "OutputInitReport": null,
+      "DeviceStrings": {},
+      "InitializationStrings": []
+    }],
+  "AuxilaryDeviceIdentifiers": [],
+  "Attributes": {}
+}


### PR DESCRIPTION
This adds support for the Wacom Intuos 2 from 2001.

P.S. Thank you for this project!
Wacom discontinued support years ago, but it's a perfectly capable tablet.
OpenTabletDriver easily allowed me to prevent it from becoming e-waste. :)