### PR TITLE
Add PTZ-930 config

### DIFF
--- a/OpenTabletDriver/Configurations/Wacom/PTZ-930.json
+++ b/OpenTabletDriver/Configurations/Wacom/PTZ-930.json
@@ -1,0 +1,51 @@
+{
+  "Name": "Wacom PTZ-930",
+  "DigitizerIdentifiers": [
+    {
+      "Width": 304.8,
+      "Height": 228.6,
+      "MaxX": 60960.0,
+      "MaxY": 45720.0,
+      "MaxPressure": 2046,
+      "ActiveReportID": {
+        "Start": 0,
+        "StartInclusive": false,
+        "End": null,
+        "EndInclusive": false
+      },
+      "VendorID": 1386,
+      "ProductID": 178,
+      "InputReportLength": 10,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
+      "FeatureInitReport": "AgI=",
+      "OutputInitReport": null,
+      "DeviceStrings": {},
+      "InitializationStrings": []
+    },
+    {
+      "Width": 304.8,
+      "Height": 228.6,
+      "MaxX": 60960.0,
+      "MaxY": 45720.0,
+      "MaxPressure": 2046,
+      "ActiveReportID": {
+        "Start": 0,
+        "StartInclusive": false,
+        "End": null,
+        "EndInclusive": false
+      },
+      "VendorID": 1386,
+      "ProductID": 178,
+      "InputReportLength": 11,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
+      "FeatureInitReport": "AgI=",
+      "OutputInitReport": null,
+      "DeviceStrings": {},
+      "InitializationStrings": []
+    }
+  ],
+  "AuxilaryDeviceIdentifiers": [],
+  "Attributes": {}
+}


### PR DESCRIPTION
Verification: 
[discord](https://discord.com/channels/615607687467761684/789348845372178482/806687723162435614)
[discord](https://discord.com/channels/615607687467761684/789348845372178482/806688112758751244)

note: the pressure max set to 2046 is not a mistake its because this tablet only has 1024 pressure levels and skips all odd numbered pressure points