### PR TITLE
Fix number fields missing decimal separator

### DIFF
--- a/OpenTabletDriver.UX/Controls/Generic/Text/DoubleNumberBox.cs
+++ b/OpenTabletDriver.UX/Controls/Generic/Text/DoubleNumberBox.cs
@@ -1,5 +1,6 @@
 using Eto.Forms;
 using OpenTabletDriver.UX.Controls.Generic.Text.Providers;
+using System.Globalization;
 
 namespace OpenTabletDriver.UX.Controls.Generic.Text
 {
@@ -9,8 +10,8 @@ namespace OpenTabletDriver.UX.Controls.Generic.Text
         {
             public override double Value
             {
-                set => Text = value.ToString();
-                get => double.TryParse(Text, out var val) ? val : default(double);
+                set => Text = value.ToString(CultureInfo.InvariantCulture);
+                get => double.TryParse(Text, NumberStyles.Any, CultureInfo.InvariantCulture, out var val) ? val : default(double);
             }
         }
     }

--- a/OpenTabletDriver.UX/Controls/Generic/Text/FloatNumberBox.cs
+++ b/OpenTabletDriver.UX/Controls/Generic/Text/FloatNumberBox.cs
@@ -1,5 +1,6 @@
 using Eto.Forms;
 using OpenTabletDriver.UX.Controls.Generic.Text.Providers;
+using System.Globalization;
 
 namespace OpenTabletDriver.UX.Controls.Generic.Text
 {
@@ -14,8 +15,8 @@ namespace OpenTabletDriver.UX.Controls.Generic.Text
         {
             public override float Value
             {
-                set => Text = value.ToString();
-                get => float.TryParse(Text, out var val) ? val : default(float);
+                set => Text = value.ToString(CultureInfo.InvariantCulture);
+                get => float.TryParse(Text, NumberStyles.Any, CultureInfo.InvariantCulture, out var val) ? val : default(float);
             }
         }
     }


### PR DESCRIPTION
Float and double TextProviders will now use culture invariant format provider.