### PR TITLE
Metadata timeout

### DIFF
--- a/OpenTabletDriver.Desktop/Reflection/Metadata/PluginMetadataCollection.cs
+++ b/OpenTabletDriver.Desktop/Reflection/Metadata/PluginMetadataCollection.cs
@@ -30,7 +30,7 @@ namespace OpenTabletDriver.Desktop.Reflection.Metadata
 
         protected static GitHubClient GitHub { get; } = new GitHubClient(new ProductHeaderValue("OpenTabletDriver"));
 
-        public static readonly PluginMetadataCollection Empty = new PluginMetadataCollection();
+        public static PluginMetadataCollection Empty => new PluginMetadataCollection();
 
         internal static HttpClient GetClient()
         {

--- a/OpenTabletDriver.Desktop/Reflection/Metadata/PluginMetadataCollection.cs
+++ b/OpenTabletDriver.Desktop/Reflection/Metadata/PluginMetadataCollection.cs
@@ -16,6 +16,7 @@ namespace OpenTabletDriver.Desktop.Reflection.Metadata
     {
         [JsonConstructor]
         protected PluginMetadataCollection()
+            : base()
         {
         }
 
@@ -28,6 +29,8 @@ namespace OpenTabletDriver.Desktop.Reflection.Metadata
         public const string REPOSITORY_NAME = "Plugin-Repository";
 
         protected static GitHubClient GitHub { get; } = new GitHubClient(new ProductHeaderValue("OpenTabletDriver"));
+
+        public static readonly PluginMetadataCollection Empty = new PluginMetadataCollection();
 
         internal static HttpClient GetClient()
         {

--- a/OpenTabletDriver.UX/Windows/PluginManagerWindow.cs
+++ b/OpenTabletDriver.UX/Windows/PluginManagerWindow.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Reflection;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
@@ -78,9 +79,39 @@ namespace OpenTabletDriver.UX.Windows
             VerticalAlignment = VerticalAlignment.Center
         };
 
-        public async Task Refresh(PluginMetadataCollection newRepository = null)
+        public async Task Refresh()
         {
-            Repository = newRepository ?? await PluginMetadataCollection.DownloadAsync();
+            var repoFetch = PluginMetadataCollection.DownloadAsync();
+            var timeoutTask = Task.Delay(TimeSpan.FromSeconds(5));
+            PluginMetadataCollection collection = null;
+
+            try
+            {
+                var completedTask = await Task.WhenAny(repoFetch, timeoutTask);
+                if (completedTask == timeoutTask)
+                    MessageBox.Show("Fetching plugin metadata timed-out. Only local plugins will be shown.", MessageBoxType.Warning);
+                else
+                    collection = await repoFetch;
+            }
+            catch (HttpRequestException)
+            {
+                MessageBox.Show("OTD cannot connect to Internet. Only local plugins will be shown.", MessageBoxType.Warning);
+            }
+            catch (Exception e)
+            {
+                MessageBox.Show($"Error: {e.Message}", MessageBoxType.Error);
+            }
+            finally
+            {
+                collection ??= PluginMetadataCollection.Empty;
+            }
+
+            await Refresh(collection);
+        }
+
+        public async Task Refresh(PluginMetadataCollection newRepository)
+        {
+            Repository = newRepository;
 
             await App.Driver.Instance.LoadPlugins();
             AppInfo.PluginManager.Load();
@@ -232,13 +263,11 @@ namespace OpenTabletDriver.UX.Windows
                 }
             }
 
-            public async void Refresh()
+            public void Refresh()
             {
                 if (MetadataReference.TryGetTarget(out var metadata))
                 {
                     var contexts = AppInfo.PluginManager.GetLoadedPlugins();
-
-                    Repository ??= await PluginMetadataCollection.DownloadAsync();
 
                     bool isInstalled = contexts.Any(t => PluginMetadata.Match(t.GetMetadata(), metadata));
 
@@ -383,10 +412,9 @@ namespace OpenTabletDriver.UX.Windows
             private readonly ObservableCollection<PluginMetadata> DisplayedPlugins = new ObservableCollection<PluginMetadata>();
             private List<DesktopPluginContext> InstalledPlugins = new List<DesktopPluginContext>();
 
-            public async void Refresh()
+            public void Refresh()
             {
                 var index = SelectedIndex;
-                Repository ??= await PluginMetadataCollection.DownloadAsync();
 
                 var installed = from plugin in AppInfo.PluginManager.GetLoadedPlugins()
                     orderby plugin.FriendlyName
@@ -460,12 +488,6 @@ namespace OpenTabletDriver.UX.Windows
 
                 this.SelectedPlugin = SelectedValue is PluginMetadata selected ? InstalledPlugins.FirstOrDefault(p => PluginMetadata.Match(selected, p.GetMetadata())) : null;
                 SelectedPluginChanged?.Invoke(this.SelectedPlugin);
-            }
-
-            protected override void OnLoadComplete(EventArgs e)
-            {
-                base.OnLoadComplete(e);
-                Refresh();
             }
         }
 

--- a/OpenTabletDriver.UX/Windows/PluginManagerWindow.cs
+++ b/OpenTabletDriver.UX/Windows/PluginManagerWindow.cs
@@ -13,6 +13,7 @@ using OpenTabletDriver.Desktop;
 using OpenTabletDriver.Desktop.Interop;
 using OpenTabletDriver.Desktop.Reflection;
 using OpenTabletDriver.Desktop.Reflection.Metadata;
+using OpenTabletDriver.Plugin;
 using OpenTabletDriver.UX.Controls.Generic;
 using OpenTabletDriver.UX.Dialogs;
 using StreamJsonRpc;
@@ -100,6 +101,7 @@ namespace OpenTabletDriver.UX.Windows
             catch (Exception e)
             {
                 MessageBox.Show($"Error: {e.Message}", MessageBoxType.Error);
+                Log.Write("PluginManager", e.Message);
             }
             finally
             {


### PR DESCRIPTION
## Test 1

Open plugin manager without internet.

### Pre-PR

- OTD crashes.

### Post-PR

- OTD shows a warning about internet, and then proceeds to only show installed plugins.

## Test 2

Open plugin manager with a bad internet.

### Pre-PR

- OTD will either hang or crash depending on the nature of the problem.

### Post-PR

- OTD timeouts after 5 seconds and then says that it timed-out fetching metadata.
- It will capture any other unhandled exception, show in message box and log to console.
- OTD then proceeds to only show installed plugins.