### PR TITLE
Addresses #700 - Unplugging Tablet Generates Incomplete Report Data

### DIFF
--- a/OpenTabletDriver/Devices/DeviceReader.cs
+++ b/OpenTabletDriver/Devices/DeviceReader.cs
@@ -72,6 +72,10 @@ namespace OpenTabletDriver.Devices
             {
                 Log.Write("Device", "Device disconnected.");
             }
+            catch (ArgumentOutOfRangeException)
+            {
+                Log.Write("Device", "Not enough report data returned by the device. Was it disconnected?");
+            }
             catch (Exception ex)
             {
                 Log.Exception(ex);


### PR DESCRIPTION
If the tablet is unplugged while reading data, `byte[] report` may be incomplete causing the parser to throw an `ArgumentOutOfBoundsException`. We can handle this by catching the exception.