### PR TITLE
Fix duplicate context menu entries on OTD Guide

### DIFF
--- a/OpenTabletDriver.UX/Controls/Area/AreaEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Area/AreaEditor.cs
@@ -9,11 +9,6 @@ namespace OpenTabletDriver.UX.Controls.Area
 {
     public class AreaEditor : Panel, IViewModelRoot<AreaViewModel>
     {
-        public AreaEditor()
-        {
-            this.ContextMenu = new ContextMenu();
-        }
-
         public AreaViewModel ViewModel
         {
             set => this.DataContext = value;
@@ -124,6 +119,8 @@ namespace OpenTabletDriver.UX.Controls.Area
                     }
                 );
             }
+
+            this.ContextMenu = new ContextMenu();
 
             this.ContextMenu.Items.GetSubmenu("Align").Items.AddRange(
                 new MenuItem[]


### PR DESCRIPTION
Apparently, `OnLoadComplete` is called on instantiated pages every time you navigate a page on `DocumentPage`. This is most likely an Eto bug.

## Test

- Open OTD Guide
- Navigate to Area Editor
- Navigate away and then back to Area Editor

### Pre-PR

![image](https://user-images.githubusercontent.com/10338031/108699372-1aa04580-7540-11eb-8b86-cb4bb6fa2dda.png)

### Post-PR

![image](https://user-images.githubusercontent.com/10338031/108699304-06f4df00-7540-11eb-8fa9-831e23215d38.png)
