### PR TITLE
Handle Missing Config Directory

### DIFF
--- a/OpenTabletDriver.UX/Windows/Configurations/ConfigurationEditor.cs
+++ b/OpenTabletDriver.UX/Windows/Configurations/ConfigurationEditor.cs
@@ -117,6 +117,7 @@ namespace OpenTabletDriver.UX.Windows.Configurations
 
         private ObservableCollection<TabletConfiguration> ReadConfigurations(DirectoryInfo dir)
         {
+            dir.Refresh();
             if (dir.Exists)
             {
                 var configs = from file in dir.GetFiles("*.json", SearchOption.AllDirectories)

--- a/OpenTabletDriver.UX/Windows/Configurations/ConfigurationEditor.cs
+++ b/OpenTabletDriver.UX/Windows/Configurations/ConfigurationEditor.cs
@@ -117,9 +117,17 @@ namespace OpenTabletDriver.UX.Windows.Configurations
 
         private ObservableCollection<TabletConfiguration> ReadConfigurations(DirectoryInfo dir)
         {
-            var configs = from file in dir.GetFiles("*.json", SearchOption.AllDirectories)
-                select Serialization.Deserialize<TabletConfiguration>(file);
-            return new ObservableCollection<TabletConfiguration>(configs);
+            if (dir.Exists)
+            {
+                var configs = from file in dir.GetFiles("*.json", SearchOption.AllDirectories)
+                              select Serialization.Deserialize<TabletConfiguration>(file);
+                return new ObservableCollection<TabletConfiguration>(configs);
+            }
+            else
+            {
+                dir.Create();
+                return new ObservableCollection<TabletConfiguration>();
+            }
         }
 
         private void WriteConfigurations(IEnumerable<TabletConfiguration> configs, DirectoryInfo dir)

--- a/OpenTabletDriver.UX/Windows/Configurations/ConfigurationEditor.cs
+++ b/OpenTabletDriver.UX/Windows/Configurations/ConfigurationEditor.cs
@@ -125,7 +125,6 @@ namespace OpenTabletDriver.UX.Windows.Configurations
             }
             else
             {
-                dir.Create();
                 return new ObservableCollection<TabletConfiguration>();
             }
         }

--- a/OpenTabletDriver.UX/Windows/Configurations/ConfigurationEditor.cs
+++ b/OpenTabletDriver.UX/Windows/Configurations/ConfigurationEditor.cs
@@ -120,7 +120,7 @@ namespace OpenTabletDriver.UX.Windows.Configurations
             if (dir.Exists)
             {
                 var configs = from file in dir.GetFiles("*.json", SearchOption.AllDirectories)
-                              select Serialization.Deserialize<TabletConfiguration>(file);
+                    select Serialization.Deserialize<TabletConfiguration>(file);
                 return new ObservableCollection<TabletConfiguration>(configs);
             }
             else


### PR DESCRIPTION
I found this bug while investigating a related issue. In my source tree the config directory didn't exist and this code was causing a hard crash. Now, if the directory doesn't exist, the function returns an empty list. The directory would then be created later in `WriteConfigurations`.