### PR TITLE
Round area width and height before displaying value

### DIFF
--- a/OpenTabletDriver.UX/Controls/Area/AreaDisplay.cs
+++ b/OpenTabletDriver.UX/Controls/Area/AreaDisplay.cs
@@ -228,7 +228,7 @@ namespace OpenTabletDriver.UX.Controls.Area
 
         private void DrawWidthText(Graphics graphics, RectangleF area)
         {
-            string widthText = $"{ViewModel.Width}{ViewModel.Unit}";
+            string widthText = $"{MathF.Round(ViewModel.Width, 3)}{ViewModel.Unit}";
             var widthTextSize = graphics.MeasureString(Font, widthText);
             var widthTextPos = new PointF(
                 area.MiddleTop.X - (widthTextSize.Width / 2),
@@ -241,7 +241,7 @@ namespace OpenTabletDriver.UX.Controls.Area
         {
             using (graphics.SaveTransformState())
             {
-                string heightText = $"{ViewModel.Height}{ViewModel.Unit}";
+                string heightText = $"{MathF.Round(ViewModel.Height, 3)}{ViewModel.Unit}";
                 var heightSize = graphics.MeasureString(Font, heightText) / 2;
                 var heightPos = new PointF(
                     -area.MiddleLeft.Y - heightSize.Width,


### PR DESCRIPTION
Values inside the rectangle are rounded off.

![image](https://user-images.githubusercontent.com/10338031/109333852-e956ab00-789a-11eb-9afe-58fa2e505e83.png)